### PR TITLE
system_apple1.c: Fix missing break in default

### DIFF
--- a/src/rp2040/system_apple1.c
+++ b/src/rp2040/system_apple1.c
@@ -242,6 +242,7 @@ static inline void handle_pia()
          }
          break;
       default:
+         break;
    }
 }
 


### PR DESCRIPTION
Got this error when building on debian 11
`[ 10%] Building C object rp2040/CMakeFiles/apple1.dir/system_apple1.c.obj
/home/fh/src/github/sorbus/src/rp2040/system_apple1.c: In function 'handle_pia':
/home/fh/src/github/sorbus/src/rp2040/system_apple1.c:244:7: error: label at end of compound statement
       default:
       ^~~~~~~`