### PR TITLE
rp2040js based test env

### DIFF
--- a/src/rp2040/CMakeLists.txt
+++ b/src/rp2040/CMakeLists.txt
@@ -60,8 +60,8 @@ function(uf2join output)
 endfunction()
 
 function(setup_target targetname incdir)
-   pico_enable_stdio_usb(${targetname} 1)
-   pico_enable_stdio_uart(${targetname} 0)
+   pico_enable_stdio_usb(${targetname} 0)
+   pico_enable_stdio_uart(${targetname} 1)
    pico_add_extra_outputs(${targetname})
    target_include_directories(${targetname} PRIVATE
       ${incdir}

--- a/src/rp2040/mcp.cmake
+++ b/src/rp2040/mcp.cmake
@@ -21,5 +21,6 @@ add_executable(mcp
 target_link_libraries(mcp
    pico_stdlib
    pico_multicore
+   hardware_flash
    )
 setup_target(mcp "mcp")

--- a/src/rp2040/sound.cmake
+++ b/src/rp2040/sound.cmake
@@ -227,6 +227,7 @@ target_include_directories(sound_sd PUBLIC
 )
 
 target_link_libraries(sound_sd
+   pico_multicore
    pico_fatfs
 )
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,21 @@
+# Makefile for building the CPU card test library
+
+CC = gcc
+CFLAGS = -O2 -fPIC -shared -Wall
+LDFLAGS = -shared
+
+# Target library
+TARGET = libcpu_card.so
+
+# Source files
+SOURCES = cpu_card_wrapper.c
+
+# Build the shared library
+$(TARGET): $(SOURCES) m65c02.h
+	$(CC) $(CFLAGS) -o $(TARGET) $(SOURCES)
+
+# Clean build artifacts
+clean:
+	rm -f $(TARGET)
+
+.PHONY: clean

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,19 @@
+# Sorbus Testing Framework
+
+A testing framework that runs the RP2040 chipset code using https://github.com/c1570/rp2040js/ and wires it up with a 65C02 CPU card emulation based on https://github.com/floooh/chips .
+
+## Running
+
+`run_tests.sh`
+
+## Architecture
+
+The framework consists of:
+
+1. **CPU Card Emulation (C code)**: `cpu_card_wrapper.c` - Wraps the m65c02 emulator to provide a simple tick() interface
+2. **FFI Bridge**: Node.js module using `koffi` library to call C functions from JavaScript
+3. **Test Runner**: `test_runner.ts` - Main emulator that:
+   - Loads RP2040 firmware
+   - Initializes RP2040 via rp2040js
+   - Connects RP2040 GPIO pins to the 65C02 CPU card
+   - Runs the emulation loop

--- a/tests/cpu_card_wrapper.c
+++ b/tests/cpu_card_wrapper.c
@@ -1,0 +1,30 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define CHIPS_IMPL
+#include "m65c02.h"
+
+// Global CPU state
+static m65c02_t cpu;
+static uint64_t pins;
+
+// Initialize the CPU card
+void cpu_card_init() {
+    pins = m65c02_init(&cpu, &(m65c02_desc_t){});
+}
+
+// Get current pins state (for initialization)
+uint64_t cpu_card_get_pins() {
+    return pins;
+}
+
+// Tick the CPU for one cycle
+// Input: pins value (uint64_t)
+// Returns: updated pins value
+uint64_t cpu_card_tick(uint64_t input_pins) {
+    pins = input_pins;
+    // Run the CPU emulation for one tick
+    pins = m65c02_tick(&cpu, pins);
+    return pins;
+}

--- a/tests/m65c02.h
+++ b/tests/m65c02.h
@@ -1,0 +1,3110 @@
+#pragma once
+/*#
+    # m65c02.h
+
+    WDC65C02 CPU emulator.
+    WIP! But runs 65C02_extended_opcodes_test.bin just fine.
+    https://github.com/floooh/chips/pull/113
+
+    Project repo: https://github.com/floooh/chips/
+
+    NOTE: this file is code-generated using m65c02_gen.py
+    in the 'codegen' directory.
+
+    Do this:
+    ~~~C
+    #define CHIPS_IMPL
+    ~~~
+    before you include this file in *one* C or C++ file to create the
+    implementation.
+
+    Optionally provide the following macros with your own implementation
+    ~~~C
+    CHIPS_ASSERT(c)
+    ~~~
+
+    ## Emulated Pins
+
+    ***********************************
+    *           +-----------+         *
+    *   IRQ --->|           |---> A0  *
+    *   NMI --->|           |...      *
+    *    RDY--->|           |---> A15 *
+    *    RES--->|           |         *
+    *    RW <---|           |         *
+    *  SYNC <---|           |         *
+    *           |           |<--> D0  *
+    *   (P0)<-->|           |...      *
+    *        ...|           |<--> D7  *
+    *   (P5)<-->|           |         *
+    *           +-----------+         *
+    ***********************************
+
+    The input/output P0..P5 pins only exist on the __hidden_m6510.
+
+    If the RDY pin is active (1) the CPU will loop on the next read
+    access until the pin goes inactive.
+
+    ## Overview
+
+    m65c02.h implements a cycle-stepped WDC65C02 CPU emulator, meaning
+    that the emulation state can be ticked forward in clock cycles instead
+    of full instructions.
+
+    To initialize the emulator, fill out a m65c02_desc_t structure with
+    initialization parameters and then call m65c02_init().
+
+        ~~~C
+        typedef struct {
+            bool bcd_disabled;          // set to true if BCD mode is disabled
+            __hidden_m6510_in_t in_cb;           // only __hidden_m6510: port IO input callback
+            __hidden_m6510_out_t out_cb;         // only __hidden_m6510: port IO output callback
+            uint8_t __hidden_m6510_io_pullup;    // only __hidden_m6510: IO port bits that are 1 when reading
+            uint8_t __hidden_m6510_io_floating;  // only __hidden_m6510: unconnected IO port pins
+            void* __hidden_m6510_user_data;      // only __hidden_m6510: optional in/out callback user data
+         } m65c02_desc_t;
+         ~~~
+
+    At the end of m65c02_init(), the CPU emulation will be at the start of
+    RESET state, and the first 7 ticks will execute the reset sequence
+    (loading the reset vector at address 0xFFFC and continuing execution
+    there.
+
+    m65c02_init() will return a 64-bit pin mask which must be the input argument
+    to the first call of m65c02_tick().
+
+    To execute instructions, call m65c02_tick() in a loop. m65c02_tick() takes
+    a 64-bit pin mask as input, executes one clock tick, and returns
+    a modified pin mask.
+
+    After executing one tick, the pin mask must be inspected, a memory read
+    or write operation must be performed, and the modified pin mask must be
+    used for the next call to m65c02_tick(). This 64-bit pin mask is how
+    the CPU emulation communicates with the outside world.
+
+    The simplest-possible execution loop would look like this:
+
+        ~~~C
+        // setup 64 kBytes of memory
+        uint8_t mem[1<<16] = { ... };
+        // initialize the CPU
+        m65c02_t cpu;
+        uint64_t pins = m65c02_init(&cpu, &(m65c02_desc_t){...});
+        while (...) {
+            // run the CPU emulation for one tick
+            pins = m65c02_tick(&cpu, pins);
+            // extract 16-bit address from pin mask
+            const uint16_t addr = M65C02_GET_ADDR(pins);
+            // perform memory access
+            if (pins & M65C02_RW) {
+                // a memory read
+                M65C02_SET_DATA(pins, mem[addr]);
+            }
+            else {
+                // a memory write
+                mem[addr] = M65C02_GET_DATA(pins);
+            }
+        }
+        ~~~
+
+    To start a reset sequence, set the M65C02_RES bit in the pin mask and
+    continue calling the m65c02_tick() function. At the start of the next
+    instruction, the CPU will initiate the 7-tick reset sequence. You do NOT
+    need to clear the M65C02_RES bit, this will be cleared when the reset
+    sequence starts.
+
+    To request an interrupt, set the M65C02_IRQ or M65C02_NMI bits in the pin
+    mask and continue calling the tick function. The interrupt sequence
+    will be initiated at the end of the current or next instruction
+    (depending on the exact cycle the interrupt pin has been set).
+
+    Unlike the M65C02_RES pin, you are also responsible for clearing the
+    interrupt pins (typically, the interrupt lines are cleared by the chip
+    which requested the interrupt once the CPU reads a chip's interrupt
+    status register to check which chip requested the interrupt).
+
+    To find out whether a new instruction is about to start, check if the
+    M65C02_SYNC pin is set.
+
+    To "goto" a random address at any time, a 'prefetch' like this is
+    necessary (this basically simulates a normal instruction fetch from
+    address 'next_pc'). This is usually only needed in "trap code" which
+    intercepts operating system calls, executes some native code to emulate
+    the operating system call, and then continue execution somewhere else:
+
+        ~~~C
+        pins = M65C02_SYNC;
+        M65C02_SET_ADDR(pins, next_pc);
+        M65C02_SET_DATA(pins, mem[next_pc]);
+        m65c02_set_pc(next_pc);
+        ~~~~
+
+    ## Functions
+    ~~~C
+    uint64_t m65c02_init(m65c02_t* cpu, const m65c02_desc_t* desc)
+    ~~~
+        Initialize a m65c02_t instance, the desc structure provides
+        initialization attributes:
+            ~~~C
+            typedef struct {
+                bool bcd_disabled;              // set to true if BCD mode is disabled
+                __hidden_m6510_in_t __hidden_m6510_in_cb;         // __hidden_m6510 only: optional port IO input callback
+                __hidden_m6510_out_t __hidden_m6510_out_cb;       // __hidden_m6510 only: optional port IO output callback
+                void* __hidden_m6510_user_data;          // __hidden_m6510 only: optional callback user data
+                uint8_t __hidden_m6510_io_pullup;        // __hidden_m6510 only: IO port bits that are 1 when reading
+                uint8_t __hidden_m6510_io_floating;      // __hidden_m6510 only: unconnected IO port pins
+            } m65c02_desc_t;
+            ~~~
+
+        To emulate a __hidden_m6510 you must provide port IO callbacks in __hidden_m6510_in_cb
+        and __hidden_m6510_out_cb, and should initialize the __hidden_m6510_io_pullup and
+        __hidden_m6510_io_floating members to indicate which of the IO pins are
+        connected or hardwired to a 1-state.
+
+    ~~~C
+    uint64_t m65c02_tick(m65c02_t* cpu, uint64_t pins)
+    ~~~
+        Tick the CPU for one clock cycle. The 'pins' argument and return value
+        is the current state of the CPU pins used to communicate with the
+        outside world (see the Overview section above for details).
+
+    ~~~C
+    uint64_t __hidden_m6510_iorq(m65c02_t* cpu, uint64_t pins)
+    ~~~
+        For the 6510, call this function after the tick callback when memory
+        access to the special addresses 0 and 1 are requested. __hidden_m6510_iorq()
+        may call the input/output callback functions provided in m65c02_desc_t.
+
+    ~~~C
+    void m65c02_set_x(m65c02_t* cpu, uint8_t val)
+    void m65c02_set_xx(m65c02_t* cpu, uint16_t val)
+    uint8_t m65c02_x(m65c02_t* cpu)
+    uint16_t m65c02_xx(m65c02_t* cpu)
+    ~~~
+        Set and get 6502 registers and flags.
+
+
+    ## zlib/libpng license
+
+    Copyright (c) 2018 Andre Weissflog
+    This software is provided 'as-is', without any express or implied warranty.
+    In no event will the authors be held liable for any damages arising from the
+    use of this software.
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+        1. The origin of this software must not be misrepresented; you must not
+        claim that you wrote the original software. If you use this software in a
+        product, an acknowledgment in the product documentation would be
+        appreciated but is not required.
+        2. Altered source versions must be plainly marked as such, and must not
+        be misrepresented as being the original software.
+        3. This notice may not be removed or altered from any source
+        distribution.
+#*/
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// address bus pins
+#define M65C02_PIN_A0    (0)
+#define M65C02_PIN_A1    (1)
+#define M65C02_PIN_A2    (2)
+#define M65C02_PIN_A3    (3)
+#define M65C02_PIN_A4    (4)
+#define M65C02_PIN_A5    (5)
+#define M65C02_PIN_A6    (6)
+#define M65C02_PIN_A7    (7)
+#define M65C02_PIN_A8    (8)
+#define M65C02_PIN_A9    (9)
+#define M65C02_PIN_A10   (10)
+#define M65C02_PIN_A11   (11)
+#define M65C02_PIN_A12   (12)
+#define M65C02_PIN_A13   (13)
+#define M65C02_PIN_A14   (14)
+#define M65C02_PIN_A15   (15)
+
+// data bus pins
+#define M65C02_PIN_D0    (16)
+#define M65C02_PIN_D1    (17)
+#define M65C02_PIN_D2    (18)
+#define M65C02_PIN_D3    (19)
+#define M65C02_PIN_D4    (20)
+#define M65C02_PIN_D5    (21)
+#define M65C02_PIN_D6    (22)
+#define M65C02_PIN_D7    (23)
+
+// control pins, these have been changed to be in line with Sorbus pinout
+#define M65C02_PIN_RW    (24)      // out: memory read or write access
+#define MXXXXX_PIN_PHI   (25)      // Sorbus only, not handled in m6502.h
+#define M65C02_PIN_RDY   (26)      // in: freeze execution at next read cycle
+#define M65C02_PIN_IRQ   (27)      // in: maskable interrupt requested
+#define M65C02_PIN_NMI   (28)      // in: non-maskable interrupt requested
+#define M65C02_PIN_RES   (29)      // request RESET
+#define M65C02_PIN_SYNC  (30)      // out: start of a new instruction
+#define __hidden_M6510_PIN_AEC   (31)      // not implemented
+
+// __hidden_m6510 IO port pins
+#define __hidden_M6510_PIN_P0        (32)
+#define __hidden_M6510_PIN_P1        (33)
+#define __hidden_M6510_PIN_P2        (34)
+#define __hidden_M6510_PIN_P3        (35)
+#define __hidden_M6510_PIN_P4        (36)
+#define __hidden_M6510_PIN_P5        (37)
+
+// pin bit masks
+#define M65C02_A0    (1ULL<<M65C02_PIN_A0)
+#define M65C02_A1    (1ULL<<M65C02_PIN_A1)
+#define M65C02_A2    (1ULL<<M65C02_PIN_A2)
+#define M65C02_A3    (1ULL<<M65C02_PIN_A3)
+#define M65C02_A4    (1ULL<<M65C02_PIN_A4)
+#define M65C02_A5    (1ULL<<M65C02_PIN_A5)
+#define M65C02_A6    (1ULL<<M65C02_PIN_A6)
+#define M65C02_A7    (1ULL<<M65C02_PIN_A7)
+#define M65C02_A8    (1ULL<<M65C02_PIN_A8)
+#define M65C02_A9    (1ULL<<M65C02_PIN_A9)
+#define M65C02_A10   (1ULL<<M65C02_PIN_A10)
+#define M65C02_A11   (1ULL<<M65C02_PIN_A11)
+#define M65C02_A12   (1ULL<<M65C02_PIN_A12)
+#define M65C02_A13   (1ULL<<M65C02_PIN_A13)
+#define M65C02_A14   (1ULL<<M65C02_PIN_A14)
+#define M65C02_A15   (1ULL<<M65C02_PIN_A15)
+#define M65C02_D0    (1ULL<<M65C02_PIN_D0)
+#define M65C02_D1    (1ULL<<M65C02_PIN_D1)
+#define M65C02_D2    (1ULL<<M65C02_PIN_D2)
+#define M65C02_D3    (1ULL<<M65C02_PIN_D3)
+#define M65C02_D4    (1ULL<<M65C02_PIN_D4)
+#define M65C02_D5    (1ULL<<M65C02_PIN_D5)
+#define M65C02_D6    (1ULL<<M65C02_PIN_D6)
+#define M65C02_D7    (1ULL<<M65C02_PIN_D7)
+#define M65C02_RW    (1ULL<<M65C02_PIN_RW)
+#define M65C02_SYNC  (1ULL<<M65C02_PIN_SYNC)
+#define M65C02_IRQ   (1ULL<<M65C02_PIN_IRQ)
+#define M65C02_NMI   (1ULL<<M65C02_PIN_NMI)
+#define M65C02_RDY   (1ULL<<M65C02_PIN_RDY)
+#define __hidden_M6510_AEC   (1ULL<<__hidden_M6510_PIN_AEC)
+#define M65C02_RES   (1ULL<<M65C02_PIN_RES)
+#define __hidden_M6510_P0    (1ULL<<__hidden_M6510_PIN_P0)
+#define __hidden_M6510_P1    (1ULL<<__hidden_M6510_PIN_P1)
+#define __hidden_M6510_P2    (1ULL<<__hidden_M6510_PIN_P2)
+#define __hidden_M6510_P3    (1ULL<<__hidden_M6510_PIN_P3)
+#define __hidden_M6510_P4    (1ULL<<__hidden_M6510_PIN_P4)
+#define __hidden_M6510_P5    (1ULL<<__hidden_M6510_PIN_P5)
+#define __hidden_M6510_PORT_BITS (__hidden_M6510_P0|__hidden_M6510_P1|__hidden_M6510_P2|__hidden_M6510_P3|__hidden_M6510_P4|__hidden_M6510_P5)
+
+/* bit mask for all CPU pins (up to bit pos 40) */
+#define M65C02_PIN_MASK ((1ULL<<40)-1)
+
+/* status indicator flags */
+#define M65C02_CF    (1<<0)  /* carry */
+#define M65C02_ZF    (1<<1)  /* zero */
+#define M65C02_IF    (1<<2)  /* IRQ disable */
+#define M65C02_DF    (1<<3)  /* decimal mode */
+#define M65C02_BF    (1<<4)  /* BRK command */
+#define M65C02_XF    (1<<5)  /* unused */
+#define M65C02_VF    (1<<6)  /* overflow */
+#define M65C02_NF    (1<<7)  /* negative */
+
+/* internal BRK state flags */
+#define M65C02_BRK_IRQ   (1<<0)  /* IRQ was triggered */
+#define M65C02_BRK_NMI   (1<<1)  /* NMI was triggered */
+#define M65C02_BRK_RESET (1<<2)  /* RES was triggered */
+
+/* __hidden_m6510 IO port callback prototypes */
+typedef void (*__hidden_m6510_out_t)(uint8_t data, void* user_data);
+typedef uint8_t (*__hidden_m6510_in_t)(void* user_data);
+
+/* the desc structure provided to m65c02_init() */
+typedef struct {
+    bool bcd_disabled;              /* set to true if BCD mode is disabled */
+    __hidden_m6510_in_t __hidden_m6510_in_cb;         /* optional port IO input callback (only on __hidden_m6510) */
+    __hidden_m6510_out_t __hidden_m6510_out_cb;       /* optional port IO output callback (only on __hidden_m6510) */
+    void* __hidden_m6510_user_data;          /* optional callback user data */
+    uint8_t __hidden_m6510_io_pullup;        /* IO port bits that are 1 when reading */
+    uint8_t __hidden_m6510_io_floating;      /* unconnected IO port pins */
+} m65c02_desc_t;
+
+/* CPU state */
+typedef struct {
+    uint16_t IR;        /* internal instruction register */
+    uint16_t PC;        /* internal program counter register */
+    uint16_t AD;        /* ADL/ADH internal register */
+    uint8_t A,X,Y,S,P;  /* regular registers */
+    uint64_t PINS;      /* last stored pin state (do NOT modify) */
+    uint16_t irq_pip;
+    uint16_t nmi_pip;
+    uint8_t brk_flags;  /* M65C02_BRK_* */
+    uint8_t bcd_enabled;
+    /* 6510 IO port state */
+    void* user_data;
+    __hidden_m6510_in_t in_cb;
+    __hidden_m6510_out_t out_cb;
+    uint8_t io_ddr;     /* 1: output, 0: input */
+    uint8_t io_inp;     /* last port input */
+    uint8_t io_out;     /* last port output */
+    uint8_t io_pins;    /* current state of IO pins (combined input/output) */
+    uint8_t io_pullup;
+    uint8_t io_floating;
+    uint8_t io_drive;
+} m65c02_t;
+
+/* initialize a new m65c02 instance and return initial pin mask */
+uint64_t m65c02_init(m65c02_t* cpu, const m65c02_desc_t* desc);
+/* execute one tick */
+uint64_t m65c02_tick(m65c02_t* cpu, uint64_t pins);
+/* perform __hidden_m6510 port IO (only call this if __hidden_M6510_CHECK_IO(pins) is true) */
+uint64_t __hidden_m6510_iorq(m65c02_t* cpu, uint64_t pins);
+// prepare m65c02_t snapshot for saving
+void m65c02_snapshot_onsave(m65c02_t* snapshot);
+// fixup m65c02_t snapshot after loading
+void m65c02_snapshot_onload(m65c02_t* snapshot, m65c02_t* sys);
+
+/* register access functions */
+void m65c02_set_a(m65c02_t* cpu, uint8_t v);
+void m65c02_set_x(m65c02_t* cpu, uint8_t v);
+void m65c02_set_y(m65c02_t* cpu, uint8_t v);
+void m65c02_set_s(m65c02_t* cpu, uint8_t v);
+void m65c02_set_p(m65c02_t* cpu, uint8_t v);
+void m65c02_set_pc(m65c02_t* cpu, uint16_t v);
+uint8_t m65c02_a(m65c02_t* cpu);
+uint8_t m65c02_x(m65c02_t* cpu);
+uint8_t m65c02_y(m65c02_t* cpu);
+uint8_t m65c02_s(m65c02_t* cpu);
+uint8_t m65c02_p(m65c02_t* cpu);
+uint16_t m65c02_pc(m65c02_t* cpu);
+
+/* extract 16-bit address bus from 64-bit pins */
+#define M65C02_GET_ADDR(p) ((uint16_t)((p)&0xFFFFULL))
+/* merge 16-bit address bus value into 64-bit pins */
+#define M65C02_SET_ADDR(p,a) {p=(((p)&~0xFFFFULL)|((a)&0xFFFFULL));}
+/* extract 8-bit data bus from 64-bit pins */
+#define M65C02_GET_DATA(p) ((uint8_t)(((p)&0xFF0000ULL)>>16))
+/* merge 8-bit data bus value into 64-bit pins */
+#define M65C02_SET_DATA(p,d) {p=(((p)&~0xFF0000ULL)|(((d)<<16)&0xFF0000ULL));}
+/* copy data bus value from other pin mask */
+#define M65C02_COPY_DATA(p0,p1) (((p0)&~0xFF0000ULL)|((p1)&0xFF0000ULL))
+/* return a pin mask with control-pins, address and data bus */
+#define M65C02_MAKE_PINS(ctrl, addr, data) ((ctrl)|(((data)<<16)&0xFF0000ULL)|((addr)&0xFFFFULL))
+/* set the port bits on the 64-bit pin mask */
+#define __hidden_M6510_SET_PORT(p,d) {p=(((p)&~__hidden_M6510_PORT_BITS)|((((uint64_t)(d))<<32)&__hidden_M6510_PORT_BITS));}
+/* __hidden_M6510: check for IO port access to address 0 or 1 */
+#define __hidden_M6510_CHECK_IO(p) (((p)&0xFFFEULL)==0)
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+/*-- IMPLEMENTATION ----------------------------------------------------------*/
+#ifdef CHIPS_IMPL
+#include <string.h>
+#ifndef CHIPS_ASSERT
+    #include <assert.h>
+    #define CHIPS_ASSERT(c) assert(c)
+#endif
+
+#if defined(__GNUC__)
+#define _M65C02_UNREACHABLE __builtin_unreachable()
+#elif defined(_MSC_VER)
+#define _M65C02_UNREACHABLE __assume(0)
+#else
+#define _M65C02_UNREACHABLE
+#endif
+
+/* register access functions */
+void m65c02_set_a(m65c02_t* cpu, uint8_t v) { cpu->A = v; }
+void m65c02_set_x(m65c02_t* cpu, uint8_t v) { cpu->X = v; }
+void m65c02_set_y(m65c02_t* cpu, uint8_t v) { cpu->Y = v; }
+void m65c02_set_s(m65c02_t* cpu, uint8_t v) { cpu->S = v; }
+void m65c02_set_p(m65c02_t* cpu, uint8_t v) { cpu->P = v; }
+void m65c02_set_pc(m65c02_t* cpu, uint16_t v) { cpu->PC = v; }
+uint8_t m65c02_a(m65c02_t* cpu) { return cpu->A; }
+uint8_t m65c02_x(m65c02_t* cpu) { return cpu->X; }
+uint8_t m65c02_y(m65c02_t* cpu) { return cpu->Y; }
+uint8_t m65c02_s(m65c02_t* cpu) { return cpu->S; }
+uint8_t m65c02_p(m65c02_t* cpu) { return cpu->P; }
+uint16_t m65c02_pc(m65c02_t* cpu) { return cpu->PC; }
+
+/* helper macros and functions for code-generated instruction decoder */
+#define _M65C02_NZ(p,v) ((p&~(M65C02_NF|M65C02_ZF))|((v&0xFF)?(v&M65C02_NF):M65C02_ZF))
+
+static inline void _m65c02_adc(m65c02_t* cpu, uint8_t val) {
+    if (cpu->bcd_enabled && (cpu->P & M65C02_DF)) {
+        /* decimal mode (credit goes to MAME) */
+        uint8_t c = cpu->P & M65C02_CF ? 1 : 0;
+        cpu->P &= ~(M65C02_NF|M65C02_VF|M65C02_ZF|M65C02_CF);
+        uint8_t al = (cpu->A & 0x0F) + (val & 0x0F) + c;
+        if (al > 9) {
+            al += 6;
+        }
+        uint8_t ah = (cpu->A >> 4) + (val >> 4) + (al > 0x0F);
+        if (0 == (uint8_t)(cpu->A + val + c)) {
+            cpu->P |= M65C02_ZF;
+        }
+        else if (ah & 0x08) {
+            cpu->P |= M65C02_NF;
+        }
+        if (~(cpu->A^val) & (cpu->A^(ah<<4)) & 0x80) {
+            cpu->P |= M65C02_VF;
+        }
+        if (ah > 9) {
+            ah += 6;
+        }
+        if (ah > 15) {
+            cpu->P |= M65C02_CF;
+        }
+        cpu->A = (ah<<4) | (al & 0x0F);
+    }
+    else {
+        /* default mode */
+        uint16_t sum = cpu->A + val + (cpu->P & M65C02_CF ? 1:0);
+        cpu->P &= ~(M65C02_VF|M65C02_CF);
+        cpu->P = _M65C02_NZ(cpu->P,sum);
+        if (~(cpu->A^val) & (cpu->A^sum) & 0x80) {
+            cpu->P |= M65C02_VF;
+        }
+        if (sum & 0xFF00) {
+            cpu->P |= M65C02_CF;
+        }
+        cpu->A = sum & 0xFF;
+    }
+}
+
+static inline void _m65c02_sbc(m65c02_t* cpu, uint8_t val) {
+    if (cpu->bcd_enabled && (cpu->P & M65C02_DF)) {
+        /* decimal mode (credit goes to MAME) */
+        uint8_t c = cpu->P & M65C02_CF ? 0 : 1;
+        cpu->P &= ~(M65C02_NF|M65C02_VF|M65C02_ZF|M65C02_CF);
+        uint16_t diff = cpu->A - val - c;
+        uint8_t al = (cpu->A & 0x0F) - (val & 0x0F) - c;
+        if ((int8_t)al < 0) {
+            al -= 6;
+        }
+        uint8_t ah = (cpu->A>>4) - (val>>4) - ((int8_t)al < 0);
+        if (0 == (uint8_t)diff) {
+            cpu->P |= M65C02_ZF;
+        }
+        else if (diff & 0x80) {
+            cpu->P |= M65C02_NF;
+        }
+        if ((cpu->A^val) & (cpu->A^diff) & 0x80) {
+            cpu->P |= M65C02_VF;
+        }
+        if (!(diff & 0xFF00)) {
+            cpu->P |= M65C02_CF;
+        }
+        if (ah & 0x80) {
+            ah -= 6;
+        }
+        cpu->A = (ah<<4) | (al & 0x0F);
+    }
+    else {
+        /* default mode */
+        uint16_t diff = cpu->A - val - (cpu->P & M65C02_CF ? 0 : 1);
+        cpu->P &= ~(M65C02_VF|M65C02_CF);
+        cpu->P = _M65C02_NZ(cpu->P, (uint8_t)diff);
+        if ((cpu->A^val) & (cpu->A^diff) & 0x80) {
+            cpu->P |= M65C02_VF;
+        }
+        if (!(diff & 0xFF00)) {
+            cpu->P |= M65C02_CF;
+        }
+        cpu->A = diff & 0xFF;
+    }
+}
+
+static inline void _m65c02_cmp(m65c02_t* cpu, uint8_t r, uint8_t v) {
+    uint16_t t = r - v;
+    cpu->P = (_M65C02_NZ(cpu->P, (uint8_t)t) & ~M65C02_CF) | ((t & 0xFF00) ? 0:M65C02_CF);
+}
+
+static inline uint8_t _m65c02_asl(m65c02_t* cpu, uint8_t v) {
+    cpu->P = (_M65C02_NZ(cpu->P, v<<1) & ~M65C02_CF) | ((v & 0x80) ? M65C02_CF:0);
+    return v<<1;
+}
+
+static inline uint8_t _m65c02_lsr(m65c02_t* cpu, uint8_t v) {
+    cpu->P = (_M65C02_NZ(cpu->P, v>>1) & ~M65C02_CF) | ((v & 0x01) ? M65C02_CF:0);
+    return v>>1;
+}
+
+static inline uint8_t _m65c02_rol(m65c02_t* cpu, uint8_t v) {
+    bool carry = cpu->P & M65C02_CF;
+    cpu->P &= ~(M65C02_NF|M65C02_ZF|M65C02_CF);
+    if (v & 0x80) {
+        cpu->P |= M65C02_CF;
+    }
+    v <<= 1;
+    if (carry) {
+        v |= 1;
+    }
+    cpu->P = _M65C02_NZ(cpu->P, v);
+    return v;
+}
+
+static inline uint8_t _m65c02_ror(m65c02_t* cpu, uint8_t v) {
+    bool carry = cpu->P & M65C02_CF;
+    cpu->P &= ~(M65C02_NF|M65C02_ZF|M65C02_CF);
+    if (v & 1) {
+        cpu->P |= M65C02_CF;
+    }
+    v >>= 1;
+    if (carry) {
+        v |= 0x80;
+    }
+    cpu->P = _M65C02_NZ(cpu->P, v);
+    return v;
+}
+
+static inline void _m65c02_bit(m65c02_t* cpu, uint8_t v) {
+    uint8_t t = cpu->A & v;
+    cpu->P &= ~(M65C02_NF|M65C02_VF|M65C02_ZF);
+    if (!t) {
+        cpu->P |= M65C02_ZF;
+    }
+    cpu->P |= v & (M65C02_NF|M65C02_VF);
+}
+
+static inline void _m65c02_arr(m65c02_t* cpu) {
+    /* undocumented, unreliable ARR instruction, but this is tested
+       by the Wolfgang Lorenz C64 test suite
+       implementation taken from MAME
+    */
+    if (cpu->bcd_enabled && (cpu->P & M65C02_DF)) {
+        bool c = cpu->P & M65C02_CF;
+        cpu->P &= ~(M65C02_NF|M65C02_VF|M65C02_ZF|M65C02_CF);
+        uint8_t a = cpu->A>>1;
+        if (c) {
+            a |= 0x80;
+        }
+        cpu->P = _M65C02_NZ(cpu->P,a);
+        if ((a ^ cpu->A) & 0x40) {
+            cpu->P |= M65C02_VF;
+        }
+        if ((cpu->A & 0xF) >= 5) {
+            a = ((a + 6) & 0xF) | (a & 0xF0);
+        }
+        if ((cpu->A & 0xF0) >= 0x50) {
+            a += 0x60;
+            cpu->P |= M65C02_CF;
+        }
+        cpu->A = a;
+    }
+    else {
+        bool c = cpu->P & M65C02_CF;
+        cpu->P &= ~(M65C02_NF|M65C02_VF|M65C02_ZF|M65C02_CF);
+        cpu->A >>= 1;
+        if (c) {
+            cpu->A |= 0x80;
+        }
+        cpu->P = _M65C02_NZ(cpu->P,cpu->A);
+        if (cpu->A & 0x40) {
+            cpu->P |= M65C02_VF|M65C02_CF;
+        }
+        if (cpu->A & 0x20) {
+            cpu->P ^= M65C02_VF;
+        }
+    }
+}
+
+/* undocumented SBX instruction:
+    AND X register with accumulator and store result in X register, then
+    subtract byte from X register (without borrow) where the
+    subtract works like a CMP instruction
+*/
+static inline void _m65c02_sbx(m65c02_t* cpu, uint8_t v) {
+    uint16_t t = (cpu->A & cpu->X) - v;
+    cpu->P = _M65C02_NZ(cpu->P, t) & ~M65C02_CF;
+    if (!(t & 0xFF00)) {
+        cpu->P |= M65C02_CF;
+    }
+    cpu->X = (uint8_t)t;
+}
+#undef _M65C02_NZ
+
+uint64_t m65c02_init(m65c02_t* c, const m65c02_desc_t* desc) {
+    CHIPS_ASSERT(c && desc);
+    memset(c, 0, sizeof(*c));
+    c->P = M65C02_ZF;
+    c->bcd_enabled = !desc->bcd_disabled;
+    c->PINS = M65C02_RW | M65C02_SYNC | M65C02_RES;
+    c->in_cb = desc->__hidden_m6510_in_cb;
+    c->out_cb = desc->__hidden_m6510_out_cb;
+    c->user_data = desc->__hidden_m6510_user_data;
+    c->io_pullup = desc->__hidden_m6510_io_pullup;
+    c->io_floating = desc->__hidden_m6510_io_floating;
+    return c->PINS;
+}
+
+/* only call this when accessing address 0 or 1 (__hidden_M6510_CHECK_IO(pins) evaluates to true) */
+uint64_t __hidden_m6510_iorq(m65c02_t* c, uint64_t pins) {
+    CHIPS_ASSERT(c->in_cb && c->out_cb);
+    if ((pins & M65C02_A0) == 0) {
+        /* address 0: access to data direction register */
+        if (pins & M65C02_RW) {
+            /* read IO direction bits */
+            M65C02_SET_DATA(pins, c->io_ddr);
+        }
+        else {
+            /* write IO direction bits and update outside world */
+            c->io_ddr = M65C02_GET_DATA(pins);
+            c->io_drive = (c->io_out & c->io_ddr) | (c->io_drive & ~c->io_ddr);
+            c->out_cb((c->io_out & c->io_ddr) | (c->io_pullup & ~c->io_ddr), c->user_data);
+            c->io_pins = (c->io_out & c->io_ddr) | (c->io_inp & ~c->io_ddr);
+        }
+    }
+    else {
+        /* address 1: perform I/O */
+        if (pins & M65C02_RW) {
+            /* an input operation */
+            c->io_inp = c->in_cb(c->user_data);
+            uint8_t val = ((c->io_inp | (c->io_floating & c->io_drive)) & ~c->io_ddr) | (c->io_out & c->io_ddr);
+            M65C02_SET_DATA(pins, val);
+        }
+        else {
+            /* an output operation */
+            c->io_out = M65C02_GET_DATA(pins);
+            c->io_drive = (c->io_out & c->io_ddr) | (c->io_drive & ~c->io_ddr);
+            c->out_cb((c->io_out & c->io_ddr) | (c->io_pullup & ~c->io_ddr), c->user_data);
+        }
+        c->io_pins = (c->io_out & c->io_ddr) | (c->io_inp & ~c->io_ddr);
+    }
+    return pins;
+}
+
+void m65c02_snapshot_onsave(m65c02_t* snapshot) {
+    CHIPS_ASSERT(snapshot);
+    snapshot->in_cb = 0;
+    snapshot->out_cb = 0;
+    snapshot->user_data = 0;
+}
+
+void m65c02_snapshot_onload(m65c02_t* snapshot, m65c02_t* sys) {
+    CHIPS_ASSERT(snapshot && sys);
+    snapshot->in_cb = sys->in_cb;
+    snapshot->out_cb = sys->out_cb;
+    snapshot->user_data = sys->user_data;
+}
+
+/* set 16-bit address in 64-bit pin mask */
+#define _SA(addr) pins=(pins&~0xFFFF)|((addr)&0xFFFFULL)
+/* extract 16-bit addess from pin mask */
+#define _GA() ((uint16_t)(pins&0xFFFFULL))
+/* set 16-bit address and 8-bit data in 64-bit pin mask */
+#define _SAD(addr,data) pins=(pins&~0xFFFFFF)|((((data)&0xFF)<<16)&0xFF0000ULL)|((addr)&0xFFFFULL)
+/* fetch next opcode byte */
+#define _FETCH() _SA(c->PC);_ON(M65C02_SYNC);
+/* set 8-bit data in 64-bit pin mask */
+#define _SD(data) pins=((pins&~0xFF0000ULL)|((((data)&0xFF)<<16)&0xFF0000ULL))
+/* extract 8-bit data from 64-bit pin mask */
+#define _GD() ((uint8_t)((pins&0xFF0000ULL)>>16))
+/* enable control pins */
+#define _ON(m) pins|=(m)
+/* disable control pins */
+#define _OFF(m) pins&=~(m)
+/* a memory read tick */
+#define _RD() _ON(M65C02_RW);
+/* a memory write tick */
+#define _WR() _OFF(M65C02_RW);
+/* set N and Z flags depending on value */
+#define _NZ(v) c->P=((c->P&~(M65C02_NF|M65C02_ZF))|((v&0xFF)?(v&M65C02_NF):M65C02_ZF))
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable:4244)   /* conversion from 'uint16_t' to 'uint8_t', possible loss of data */
+#endif
+
+uint64_t m65c02_tick(m65c02_t* c, uint64_t pins) {
+    if (pins & (M65C02_SYNC|M65C02_IRQ|M65C02_NMI|M65C02_RDY|M65C02_RES)) {
+        // interrupt detection also works in RDY phases, but only NMI is "sticky"
+
+        // NMI is edge-triggered
+        if (0 != ((pins & (pins ^ c->PINS)) & M65C02_NMI)) {
+            c->nmi_pip |= 0x100;
+        }
+        // IRQ test is level triggered
+        if ((pins & M65C02_IRQ) && (0 == (c->P & M65C02_IF))) {
+            c->irq_pip |= 0x100;
+        }
+
+        // RDY pin is only checked during read cycles
+        if ((pins & (M65C02_RW|M65C02_RDY)) == (M65C02_RW|M65C02_RDY)) {
+            __hidden_M6510_SET_PORT(pins, c->io_pins);
+            c->PINS = pins;
+            c->irq_pip <<= 1;
+            return pins;
+        }
+        if (pins & M65C02_SYNC) {
+            // load new instruction into 'instruction register' and restart tick counter
+            c->IR = _GD()<<3;
+            _OFF(M65C02_SYNC);
+
+            // check IRQ, NMI and RES state
+            //  - IRQ is level-triggered and must be active in the full cycle
+            //    before SYNC
+            //  - NMI is edge-triggered, and the change must have happened in
+            //    any cycle before SYNC
+            //  - RES behaves slightly different than on a real 6502, we go
+            //    into RES state as soon as the pin goes active, from there
+            //    on, behaviour is 'standard'
+            if (0 != (c->irq_pip & 0x400)) {
+                c->brk_flags |= M65C02_BRK_IRQ;
+            }
+            if (0 != (c->nmi_pip & 0xFC00)) {
+                c->brk_flags |= M65C02_BRK_NMI;
+            }
+            if (0 != (pins & M65C02_RES)) {
+                c->brk_flags |= M65C02_BRK_RESET;
+                c->io_ddr = 0;
+                c->io_out = 0;
+                c->io_inp = 0;
+                c->io_pins = 0;
+            }
+            c->irq_pip &= 0x3FF;
+            c->nmi_pip &= 0x3FF;
+
+            // if interrupt or reset was requested, force a BRK instruction
+            if (c->brk_flags) {
+                c->IR = 0;
+                c->P &= ~M65C02_BF;
+                pins &= ~M65C02_RES;
+            }
+            else {
+                c->PC++;
+            }
+        }
+    }
+    // reads are default, writes are special
+    _RD();
+    switch (c->IR++) {
+    // <% decoder
+    /* BRK  */
+        case (0x00<<3)|0: _SA(c->PC);break;
+        case (0x00<<3)|1: if(0==(c->brk_flags&(M65C02_BRK_IRQ|M65C02_BRK_NMI))){c->PC++;}_SAD(0x0100|c->S--,c->PC>>8);if(0==(c->brk_flags&M65C02_BRK_RESET)){_WR();}break;
+        case (0x00<<3)|2: _SAD(0x0100|c->S--,c->PC);if(0==(c->brk_flags&M65C02_BRK_RESET)){_WR();}break;
+        case (0x00<<3)|3: _SAD(0x0100|c->S--,c->P|M65C02_XF);if(c->brk_flags&M65C02_BRK_RESET){c->AD=0xFFFC;}else{_WR();if(c->brk_flags&M65C02_BRK_NMI){c->AD=0xFFFA;}else{c->AD=0xFFFE;}}break;
+        case (0x00<<3)|4: _SA(c->AD++);c->P&=~M65C02_DF;c->P|=(M65C02_IF|M65C02_BF);c->brk_flags=0; /* RES/NMI hijacking */break;
+        case (0x00<<3)|5: _SA(c->AD);c->AD=_GD(); /* NMI "half-hijacking" not possible */break;
+        case (0x00<<3)|6: c->PC=(_GD()<<8)|c->AD;_FETCH();break;
+        case (0x00<<3)|7: assert(false);break;
+    /* ORA (zp,X) */
+        case (0x01<<3)|0: _SA(c->PC++);break;
+        case (0x01<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0x01<<3)|2: c->AD=(c->AD+c->X)&0xFF;_SA(c->AD);break;
+        case (0x01<<3)|3: _SA((c->AD+1)&0xFF);c->AD=_GD();break;
+        case (0x01<<3)|4: _SA((_GD()<<8)|c->AD);break;
+        case (0x01<<3)|5: c->A|=_GD();_NZ(c->A);_FETCH();break;
+        case (0x01<<3)|6: assert(false);break;
+        case (0x01<<3)|7: assert(false);break;
+    /* LDD # */
+        case (0x02<<3)|0: _SA(c->PC++);break;
+        case (0x02<<3)|1: _FETCH();break;
+        case (0x02<<3)|2: assert(false);break;
+        case (0x02<<3)|3: assert(false);break;
+        case (0x02<<3)|4: assert(false);break;
+        case (0x02<<3)|5: assert(false);break;
+        case (0x02<<3)|6: assert(false);break;
+        case (0x02<<3)|7: assert(false);break;
+    /* NOP (zp,X) */
+        case (0x03<<3)|0: _SA(c->PC);break;
+        case (0x03<<3)|1: _FETCH();break;
+        case (0x03<<3)|2: assert(false);break;
+        case (0x03<<3)|3: assert(false);break;
+        case (0x03<<3)|4: assert(false);break;
+        case (0x03<<3)|5: assert(false);break;
+        case (0x03<<3)|6: assert(false);break;
+        case (0x03<<3)|7: assert(false);break;
+    /* TSB zp */
+        case (0x04<<3)|0: _SA(c->PC++);break;
+        case (0x04<<3)|1: _SA(_GD());break;
+        case (0x04<<3)|2: c->AD=_GD();break;
+        case (0x04<<3)|3: if(c->AD&c->A){c->P&=~M65C02_ZF;}else{c->P|=M65C02_ZF;};_SD(c->AD|c->A);_WR();break;
+        case (0x04<<3)|4: _FETCH();break;
+        case (0x04<<3)|5: assert(false);break;
+        case (0x04<<3)|6: assert(false);break;
+        case (0x04<<3)|7: assert(false);break;
+    /* ORA zp */
+        case (0x05<<3)|0: _SA(c->PC++);break;
+        case (0x05<<3)|1: _SA(_GD());break;
+        case (0x05<<3)|2: c->A|=_GD();_NZ(c->A);_FETCH();break;
+        case (0x05<<3)|3: assert(false);break;
+        case (0x05<<3)|4: assert(false);break;
+        case (0x05<<3)|5: assert(false);break;
+        case (0x05<<3)|6: assert(false);break;
+        case (0x05<<3)|7: assert(false);break;
+    /* ASL zp */
+        case (0x06<<3)|0: _SA(c->PC++);break;
+        case (0x06<<3)|1: _SA(_GD());break;
+        case (0x06<<3)|2: c->AD=_GD();_WR();break;
+        case (0x06<<3)|3: _SD(_m65c02_asl(c,c->AD));_WR();break;
+        case (0x06<<3)|4: _FETCH();break;
+        case (0x06<<3)|5: assert(false);break;
+        case (0x06<<3)|6: assert(false);break;
+        case (0x06<<3)|7: assert(false);break;
+    /* RMB0 zp */
+        case (0x07<<3)|0: _SA(c->PC++);break;
+        case (0x07<<3)|1: _SA(_GD());break;
+        case (0x07<<3)|2: _SD(_GD()&(~(1<<0)));_WR();break;
+        case (0x07<<3)|3: _FETCH();break;
+        case (0x07<<3)|4: assert(false);break;
+        case (0x07<<3)|5: assert(false);break;
+        case (0x07<<3)|6: assert(false);break;
+        case (0x07<<3)|7: assert(false);break;
+    /* PHP  */
+        case (0x08<<3)|0: _SA(c->PC);break;
+        case (0x08<<3)|1: _SAD(0x0100|c->S--,c->P|M65C02_XF);_WR();break;
+        case (0x08<<3)|2: _FETCH();break;
+        case (0x08<<3)|3: assert(false);break;
+        case (0x08<<3)|4: assert(false);break;
+        case (0x08<<3)|5: assert(false);break;
+        case (0x08<<3)|6: assert(false);break;
+        case (0x08<<3)|7: assert(false);break;
+    /* ORA # */
+        case (0x09<<3)|0: _SA(c->PC++);break;
+        case (0x09<<3)|1: c->A|=_GD();_NZ(c->A);_FETCH();break;
+        case (0x09<<3)|2: assert(false);break;
+        case (0x09<<3)|3: assert(false);break;
+        case (0x09<<3)|4: assert(false);break;
+        case (0x09<<3)|5: assert(false);break;
+        case (0x09<<3)|6: assert(false);break;
+        case (0x09<<3)|7: assert(false);break;
+    /* ASLA  */
+        case (0x0A<<3)|0: _SA(c->PC);break;
+        case (0x0A<<3)|1: c->A=_m65c02_asl(c,c->A);_FETCH();break;
+        case (0x0A<<3)|2: assert(false);break;
+        case (0x0A<<3)|3: assert(false);break;
+        case (0x0A<<3)|4: assert(false);break;
+        case (0x0A<<3)|5: assert(false);break;
+        case (0x0A<<3)|6: assert(false);break;
+        case (0x0A<<3)|7: assert(false);break;
+    /* NOP # */
+        case (0x0B<<3)|0: _SA(c->PC);break;
+        case (0x0B<<3)|1: _FETCH();break;
+        case (0x0B<<3)|2: assert(false);break;
+        case (0x0B<<3)|3: assert(false);break;
+        case (0x0B<<3)|4: assert(false);break;
+        case (0x0B<<3)|5: assert(false);break;
+        case (0x0B<<3)|6: assert(false);break;
+        case (0x0B<<3)|7: assert(false);break;
+    /* TSB abs */
+        case (0x0C<<3)|0: _SA(c->PC++);break;
+        case (0x0C<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x0C<<3)|2: _SA((_GD()<<8)|c->AD);break;
+        case (0x0C<<3)|3: c->AD=_GD();break;
+        case (0x0C<<3)|4: if(c->AD&c->A){c->P&=~M65C02_ZF;}else{c->P|=M65C02_ZF;};_SD(c->AD|c->A);_WR();break;
+        case (0x0C<<3)|5: _FETCH();break;
+        case (0x0C<<3)|6: assert(false);break;
+        case (0x0C<<3)|7: assert(false);break;
+    /* ORA abs */
+        case (0x0D<<3)|0: _SA(c->PC++);break;
+        case (0x0D<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x0D<<3)|2: _SA((_GD()<<8)|c->AD);break;
+        case (0x0D<<3)|3: c->A|=_GD();_NZ(c->A);_FETCH();break;
+        case (0x0D<<3)|4: assert(false);break;
+        case (0x0D<<3)|5: assert(false);break;
+        case (0x0D<<3)|6: assert(false);break;
+        case (0x0D<<3)|7: assert(false);break;
+    /* ASL abs */
+        case (0x0E<<3)|0: _SA(c->PC++);break;
+        case (0x0E<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x0E<<3)|2: _SA((_GD()<<8)|c->AD);break;
+        case (0x0E<<3)|3: c->AD=_GD();_WR();break;
+        case (0x0E<<3)|4: _SD(_m65c02_asl(c,c->AD));_WR();break;
+        case (0x0E<<3)|5: _FETCH();break;
+        case (0x0E<<3)|6: assert(false);break;
+        case (0x0E<<3)|7: assert(false);break;
+    /* BBR0 zp,rel */
+        case (0x0F<<3)|0: _SA(c->PC++);break;
+        case (0x0F<<3)|1: _SA(_GD());break;
+        case (0x0F<<3)|2: c->AD=_GD();_SA(c->PC++);break;
+        case (0x0F<<3)|3: if(!(c->AD&(1<<0))){c->PC=c->PC+(int8_t)_GD();_FETCH();};_FETCH();break;
+        case (0x0F<<3)|4: assert(false);break;
+        case (0x0F<<3)|5: assert(false);break;
+        case (0x0F<<3)|6: assert(false);break;
+        case (0x0F<<3)|7: assert(false);break;
+    /* BPL # */
+        case (0x10<<3)|0: _SA(c->PC++);break;
+        case (0x10<<3)|1: _SA(c->PC);c->AD=c->PC+(int8_t)_GD();if((c->P&0x80)!=0x0){_FETCH();};break;
+        case (0x10<<3)|2: _SA((c->PC&0xFF00)|(c->AD&0x00FF));if((c->AD&0xFF00)==(c->PC&0xFF00)){c->PC=c->AD;c->irq_pip>>=1;c->nmi_pip>>=1;_FETCH();};break;
+        case (0x10<<3)|3: c->PC=c->AD;_FETCH();break;
+        case (0x10<<3)|4: assert(false);break;
+        case (0x10<<3)|5: assert(false);break;
+        case (0x10<<3)|6: assert(false);break;
+        case (0x10<<3)|7: assert(false);break;
+    /* ORA (zp),Y */
+        case (0x11<<3)|0: _SA(c->PC++);break;
+        case (0x11<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0x11<<3)|2: _SA((c->AD+1)&0xFF);c->AD=_GD();break;
+        case (0x11<<3)|3: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->Y)&0xFF));c->IR+=(~((c->AD>>8)-((c->AD+c->Y)>>8)))&1;break;
+        case (0x11<<3)|4: _SA(c->AD+c->Y);break;
+        case (0x11<<3)|5: c->A|=_GD();_NZ(c->A);_FETCH();break;
+        case (0x11<<3)|6: assert(false);break;
+        case (0x11<<3)|7: assert(false);break;
+    /* ORA (zp) */
+        case (0x12<<3)|0: _SA(c->PC++);break;
+        case (0x12<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0x12<<3)|2: _SA((c->AD+1)&0xFF);c->AD=_GD();break;
+        case (0x12<<3)|3: _SA((_GD()<<8)|c->AD);break;
+        case (0x12<<3)|4: c->A|=_GD();_NZ(c->A);_FETCH();break;
+        case (0x12<<3)|5: assert(false);break;
+        case (0x12<<3)|6: assert(false);break;
+        case (0x12<<3)|7: assert(false);break;
+    /* NOP (zp),Y */
+        case (0x13<<3)|0: _SA(c->PC);break;
+        case (0x13<<3)|1: _FETCH();break;
+        case (0x13<<3)|2: assert(false);break;
+        case (0x13<<3)|3: assert(false);break;
+        case (0x13<<3)|4: assert(false);break;
+        case (0x13<<3)|5: assert(false);break;
+        case (0x13<<3)|6: assert(false);break;
+        case (0x13<<3)|7: assert(false);break;
+    /* TRB zp */
+        case (0x14<<3)|0: _SA(c->PC++);break;
+        case (0x14<<3)|1: _SA(_GD());break;
+        case (0x14<<3)|2: c->AD=_GD();break;
+        case (0x14<<3)|3: if(c->AD&c->A){c->P&=~M65C02_ZF;}else{c->P|=M65C02_ZF;};_SD(c->AD&~c->A);_WR();break;
+        case (0x14<<3)|4: _FETCH();break;
+        case (0x14<<3)|5: assert(false);break;
+        case (0x14<<3)|6: assert(false);break;
+        case (0x14<<3)|7: assert(false);break;
+    /* ORA zp,X */
+        case (0x15<<3)|0: _SA(c->PC++);break;
+        case (0x15<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0x15<<3)|2: _SA((c->AD+c->X)&0x00FF);break;
+        case (0x15<<3)|3: c->A|=_GD();_NZ(c->A);_FETCH();break;
+        case (0x15<<3)|4: assert(false);break;
+        case (0x15<<3)|5: assert(false);break;
+        case (0x15<<3)|6: assert(false);break;
+        case (0x15<<3)|7: assert(false);break;
+    /* ASL zp,X */
+        case (0x16<<3)|0: _SA(c->PC++);break;
+        case (0x16<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0x16<<3)|2: _SA((c->AD+c->X)&0x00FF);break;
+        case (0x16<<3)|3: c->AD=_GD();_WR();break;
+        case (0x16<<3)|4: _SD(_m65c02_asl(c,c->AD));_WR();break;
+        case (0x16<<3)|5: _FETCH();break;
+        case (0x16<<3)|6: assert(false);break;
+        case (0x16<<3)|7: assert(false);break;
+    /* RMB1 zp */
+        case (0x17<<3)|0: _SA(c->PC++);break;
+        case (0x17<<3)|1: _SA(_GD());break;
+        case (0x17<<3)|2: _SD(_GD()&(~(1<<1)));_WR();break;
+        case (0x17<<3)|3: _FETCH();break;
+        case (0x17<<3)|4: assert(false);break;
+        case (0x17<<3)|5: assert(false);break;
+        case (0x17<<3)|6: assert(false);break;
+        case (0x17<<3)|7: assert(false);break;
+    /* CLC  */
+        case (0x18<<3)|0: _SA(c->PC);break;
+        case (0x18<<3)|1: c->P&=~0x1;_FETCH();break;
+        case (0x18<<3)|2: assert(false);break;
+        case (0x18<<3)|3: assert(false);break;
+        case (0x18<<3)|4: assert(false);break;
+        case (0x18<<3)|5: assert(false);break;
+        case (0x18<<3)|6: assert(false);break;
+        case (0x18<<3)|7: assert(false);break;
+    /* ORA abs,Y */
+        case (0x19<<3)|0: _SA(c->PC++);break;
+        case (0x19<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x19<<3)|2: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->Y)&0xFF));c->IR+=(~((c->AD>>8)-((c->AD+c->Y)>>8)))&1;break;
+        case (0x19<<3)|3: _SA(c->AD+c->Y);break;
+        case (0x19<<3)|4: c->A|=_GD();_NZ(c->A);_FETCH();break;
+        case (0x19<<3)|5: assert(false);break;
+        case (0x19<<3)|6: assert(false);break;
+        case (0x19<<3)|7: assert(false);break;
+    /* INC A  */
+        case (0x1A<<3)|0: _SA(c->PC);break;
+        case (0x1A<<3)|1: c->A++;_NZ(c->A);_FETCH();break;
+        case (0x1A<<3)|2: assert(false);break;
+        case (0x1A<<3)|3: assert(false);break;
+        case (0x1A<<3)|4: assert(false);break;
+        case (0x1A<<3)|5: assert(false);break;
+        case (0x1A<<3)|6: assert(false);break;
+        case (0x1A<<3)|7: assert(false);break;
+    /* NOP abs,Y */
+        case (0x1B<<3)|0: _SA(c->PC);break;
+        case (0x1B<<3)|1: _FETCH();break;
+        case (0x1B<<3)|2: assert(false);break;
+        case (0x1B<<3)|3: assert(false);break;
+        case (0x1B<<3)|4: assert(false);break;
+        case (0x1B<<3)|5: assert(false);break;
+        case (0x1B<<3)|6: assert(false);break;
+        case (0x1B<<3)|7: assert(false);break;
+    /* TRB abs */
+        case (0x1C<<3)|0: _SA(c->PC++);break;
+        case (0x1C<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x1C<<3)|2: _SA((_GD()<<8)|c->AD);break;
+        case (0x1C<<3)|3: c->AD=_GD();break;
+        case (0x1C<<3)|4: if(c->AD&c->A){c->P&=~M65C02_ZF;}else{c->P|=M65C02_ZF;};_SD(c->AD&~c->A);_WR();break;
+        case (0x1C<<3)|5: _FETCH();break;
+        case (0x1C<<3)|6: assert(false);break;
+        case (0x1C<<3)|7: assert(false);break;
+    /* ORA abs,X */
+        case (0x1D<<3)|0: _SA(c->PC++);break;
+        case (0x1D<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x1D<<3)|2: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->X)&0xFF));c->IR+=(~((c->AD>>8)-((c->AD+c->X)>>8)))&1;break;
+        case (0x1D<<3)|3: _SA(c->AD+c->X);break;
+        case (0x1D<<3)|4: c->A|=_GD();_NZ(c->A);_FETCH();break;
+        case (0x1D<<3)|5: assert(false);break;
+        case (0x1D<<3)|6: assert(false);break;
+        case (0x1D<<3)|7: assert(false);break;
+    /* ASL abs,X */
+        case (0x1E<<3)|0: _SA(c->PC++);break;
+        case (0x1E<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x1E<<3)|2: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->X)&0xFF));break;
+        case (0x1E<<3)|3: _SA(c->AD+c->X);break;
+        case (0x1E<<3)|4: c->AD=_GD();_WR();break;
+        case (0x1E<<3)|5: _SD(_m65c02_asl(c,c->AD));_WR();break;
+        case (0x1E<<3)|6: _FETCH();break;
+        case (0x1E<<3)|7: assert(false);break;
+    /* BBR1 zp,rel */
+        case (0x1F<<3)|0: _SA(c->PC++);break;
+        case (0x1F<<3)|1: _SA(_GD());break;
+        case (0x1F<<3)|2: c->AD=_GD();_SA(c->PC++);break;
+        case (0x1F<<3)|3: if(!(c->AD&(1<<1))){c->PC=c->PC+(int8_t)_GD();_FETCH();};_FETCH();break;
+        case (0x1F<<3)|4: assert(false);break;
+        case (0x1F<<3)|5: assert(false);break;
+        case (0x1F<<3)|6: assert(false);break;
+        case (0x1F<<3)|7: assert(false);break;
+    /* JSR  */
+        case (0x20<<3)|0: _SA(c->PC++);break;
+        case (0x20<<3)|1: _SA(0x0100|c->S);c->AD=_GD();break;
+        case (0x20<<3)|2: _SAD(0x0100|c->S--,c->PC>>8);_WR();break;
+        case (0x20<<3)|3: _SAD(0x0100|c->S--,c->PC);_WR();break;
+        case (0x20<<3)|4: _SA(c->PC);break;
+        case (0x20<<3)|5: c->PC=(_GD()<<8)|c->AD;_FETCH();break;
+        case (0x20<<3)|6: assert(false);break;
+        case (0x20<<3)|7: assert(false);break;
+    /* AND (zp,X) */
+        case (0x21<<3)|0: _SA(c->PC++);break;
+        case (0x21<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0x21<<3)|2: c->AD=(c->AD+c->X)&0xFF;_SA(c->AD);break;
+        case (0x21<<3)|3: _SA((c->AD+1)&0xFF);c->AD=_GD();break;
+        case (0x21<<3)|4: _SA((_GD()<<8)|c->AD);break;
+        case (0x21<<3)|5: c->A&=_GD();_NZ(c->A);_FETCH();break;
+        case (0x21<<3)|6: assert(false);break;
+        case (0x21<<3)|7: assert(false);break;
+    /* LDD # */
+        case (0x22<<3)|0: _SA(c->PC++);break;
+        case (0x22<<3)|1: _FETCH();break;
+        case (0x22<<3)|2: assert(false);break;
+        case (0x22<<3)|3: assert(false);break;
+        case (0x22<<3)|4: assert(false);break;
+        case (0x22<<3)|5: assert(false);break;
+        case (0x22<<3)|6: assert(false);break;
+        case (0x22<<3)|7: assert(false);break;
+    /* NOP (zp,X) */
+        case (0x23<<3)|0: _SA(c->PC);break;
+        case (0x23<<3)|1: _FETCH();break;
+        case (0x23<<3)|2: assert(false);break;
+        case (0x23<<3)|3: assert(false);break;
+        case (0x23<<3)|4: assert(false);break;
+        case (0x23<<3)|5: assert(false);break;
+        case (0x23<<3)|6: assert(false);break;
+        case (0x23<<3)|7: assert(false);break;
+    /* BIT zp */
+        case (0x24<<3)|0: _SA(c->PC++);break;
+        case (0x24<<3)|1: _SA(_GD());break;
+        case (0x24<<3)|2: _m65c02_bit(c,_GD());_FETCH();break;
+        case (0x24<<3)|3: assert(false);break;
+        case (0x24<<3)|4: assert(false);break;
+        case (0x24<<3)|5: assert(false);break;
+        case (0x24<<3)|6: assert(false);break;
+        case (0x24<<3)|7: assert(false);break;
+    /* AND zp */
+        case (0x25<<3)|0: _SA(c->PC++);break;
+        case (0x25<<3)|1: _SA(_GD());break;
+        case (0x25<<3)|2: c->A&=_GD();_NZ(c->A);_FETCH();break;
+        case (0x25<<3)|3: assert(false);break;
+        case (0x25<<3)|4: assert(false);break;
+        case (0x25<<3)|5: assert(false);break;
+        case (0x25<<3)|6: assert(false);break;
+        case (0x25<<3)|7: assert(false);break;
+    /* ROL zp */
+        case (0x26<<3)|0: _SA(c->PC++);break;
+        case (0x26<<3)|1: _SA(_GD());break;
+        case (0x26<<3)|2: c->AD=_GD();_WR();break;
+        case (0x26<<3)|3: _SD(_m65c02_rol(c,c->AD));_WR();break;
+        case (0x26<<3)|4: _FETCH();break;
+        case (0x26<<3)|5: assert(false);break;
+        case (0x26<<3)|6: assert(false);break;
+        case (0x26<<3)|7: assert(false);break;
+    /* RMB2 zp */
+        case (0x27<<3)|0: _SA(c->PC++);break;
+        case (0x27<<3)|1: _SA(_GD());break;
+        case (0x27<<3)|2: _SD(_GD()&(~(1<<2)));_WR();break;
+        case (0x27<<3)|3: _FETCH();break;
+        case (0x27<<3)|4: assert(false);break;
+        case (0x27<<3)|5: assert(false);break;
+        case (0x27<<3)|6: assert(false);break;
+        case (0x27<<3)|7: assert(false);break;
+    /* PLP  */
+        case (0x28<<3)|0: _SA(c->PC);break;
+        case (0x28<<3)|1: _SA(0x0100|c->S++);break;
+        case (0x28<<3)|2: _SA(0x0100|c->S);break;
+        case (0x28<<3)|3: c->P=(_GD()|M65C02_BF)&~M65C02_XF;_FETCH();break;
+        case (0x28<<3)|4: assert(false);break;
+        case (0x28<<3)|5: assert(false);break;
+        case (0x28<<3)|6: assert(false);break;
+        case (0x28<<3)|7: assert(false);break;
+    /* AND # */
+        case (0x29<<3)|0: _SA(c->PC++);break;
+        case (0x29<<3)|1: c->A&=_GD();_NZ(c->A);_FETCH();break;
+        case (0x29<<3)|2: assert(false);break;
+        case (0x29<<3)|3: assert(false);break;
+        case (0x29<<3)|4: assert(false);break;
+        case (0x29<<3)|5: assert(false);break;
+        case (0x29<<3)|6: assert(false);break;
+        case (0x29<<3)|7: assert(false);break;
+    /* ROLA  */
+        case (0x2A<<3)|0: _SA(c->PC);break;
+        case (0x2A<<3)|1: c->A=_m65c02_rol(c,c->A);_FETCH();break;
+        case (0x2A<<3)|2: assert(false);break;
+        case (0x2A<<3)|3: assert(false);break;
+        case (0x2A<<3)|4: assert(false);break;
+        case (0x2A<<3)|5: assert(false);break;
+        case (0x2A<<3)|6: assert(false);break;
+        case (0x2A<<3)|7: assert(false);break;
+    /* NOP # */
+        case (0x2B<<3)|0: _SA(c->PC);break;
+        case (0x2B<<3)|1: _FETCH();break;
+        case (0x2B<<3)|2: assert(false);break;
+        case (0x2B<<3)|3: assert(false);break;
+        case (0x2B<<3)|4: assert(false);break;
+        case (0x2B<<3)|5: assert(false);break;
+        case (0x2B<<3)|6: assert(false);break;
+        case (0x2B<<3)|7: assert(false);break;
+    /* BIT abs */
+        case (0x2C<<3)|0: _SA(c->PC++);break;
+        case (0x2C<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x2C<<3)|2: _SA((_GD()<<8)|c->AD);break;
+        case (0x2C<<3)|3: _m65c02_bit(c,_GD());_FETCH();break;
+        case (0x2C<<3)|4: assert(false);break;
+        case (0x2C<<3)|5: assert(false);break;
+        case (0x2C<<3)|6: assert(false);break;
+        case (0x2C<<3)|7: assert(false);break;
+    /* AND abs */
+        case (0x2D<<3)|0: _SA(c->PC++);break;
+        case (0x2D<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x2D<<3)|2: _SA((_GD()<<8)|c->AD);break;
+        case (0x2D<<3)|3: c->A&=_GD();_NZ(c->A);_FETCH();break;
+        case (0x2D<<3)|4: assert(false);break;
+        case (0x2D<<3)|5: assert(false);break;
+        case (0x2D<<3)|6: assert(false);break;
+        case (0x2D<<3)|7: assert(false);break;
+    /* ROL abs */
+        case (0x2E<<3)|0: _SA(c->PC++);break;
+        case (0x2E<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x2E<<3)|2: _SA((_GD()<<8)|c->AD);break;
+        case (0x2E<<3)|3: c->AD=_GD();_WR();break;
+        case (0x2E<<3)|4: _SD(_m65c02_rol(c,c->AD));_WR();break;
+        case (0x2E<<3)|5: _FETCH();break;
+        case (0x2E<<3)|6: assert(false);break;
+        case (0x2E<<3)|7: assert(false);break;
+    /* BBR2 zp,rel */
+        case (0x2F<<3)|0: _SA(c->PC++);break;
+        case (0x2F<<3)|1: _SA(_GD());break;
+        case (0x2F<<3)|2: c->AD=_GD();_SA(c->PC++);break;
+        case (0x2F<<3)|3: if(!(c->AD&(1<<2))){c->PC=c->PC+(int8_t)_GD();_FETCH();};_FETCH();break;
+        case (0x2F<<3)|4: assert(false);break;
+        case (0x2F<<3)|5: assert(false);break;
+        case (0x2F<<3)|6: assert(false);break;
+        case (0x2F<<3)|7: assert(false);break;
+    /* BMI # */
+        case (0x30<<3)|0: _SA(c->PC++);break;
+        case (0x30<<3)|1: _SA(c->PC);c->AD=c->PC+(int8_t)_GD();if((c->P&0x80)!=0x80){_FETCH();};break;
+        case (0x30<<3)|2: _SA((c->PC&0xFF00)|(c->AD&0x00FF));if((c->AD&0xFF00)==(c->PC&0xFF00)){c->PC=c->AD;c->irq_pip>>=1;c->nmi_pip>>=1;_FETCH();};break;
+        case (0x30<<3)|3: c->PC=c->AD;_FETCH();break;
+        case (0x30<<3)|4: assert(false);break;
+        case (0x30<<3)|5: assert(false);break;
+        case (0x30<<3)|6: assert(false);break;
+        case (0x30<<3)|7: assert(false);break;
+    /* AND (zp),Y */
+        case (0x31<<3)|0: _SA(c->PC++);break;
+        case (0x31<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0x31<<3)|2: _SA((c->AD+1)&0xFF);c->AD=_GD();break;
+        case (0x31<<3)|3: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->Y)&0xFF));c->IR+=(~((c->AD>>8)-((c->AD+c->Y)>>8)))&1;break;
+        case (0x31<<3)|4: _SA(c->AD+c->Y);break;
+        case (0x31<<3)|5: c->A&=_GD();_NZ(c->A);_FETCH();break;
+        case (0x31<<3)|6: assert(false);break;
+        case (0x31<<3)|7: assert(false);break;
+    /* AND (zp) */
+        case (0x32<<3)|0: _SA(c->PC++);break;
+        case (0x32<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0x32<<3)|2: _SA((c->AD+1)&0xFF);c->AD=_GD();break;
+        case (0x32<<3)|3: _SA((_GD()<<8)|c->AD);break;
+        case (0x32<<3)|4: c->A&=_GD();_NZ(c->A);_FETCH();break;
+        case (0x32<<3)|5: assert(false);break;
+        case (0x32<<3)|6: assert(false);break;
+        case (0x32<<3)|7: assert(false);break;
+    /* NOP (zp),Y */
+        case (0x33<<3)|0: _SA(c->PC);break;
+        case (0x33<<3)|1: _FETCH();break;
+        case (0x33<<3)|2: assert(false);break;
+        case (0x33<<3)|3: assert(false);break;
+        case (0x33<<3)|4: assert(false);break;
+        case (0x33<<3)|5: assert(false);break;
+        case (0x33<<3)|6: assert(false);break;
+        case (0x33<<3)|7: assert(false);break;
+    /* BIT zp,X */
+        case (0x34<<3)|0: _SA(c->PC++);break;
+        case (0x34<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0x34<<3)|2: _SA((c->AD+c->X)&0x00FF);break;
+        case (0x34<<3)|3: _m65c02_bit(c,_GD());_FETCH();break;
+        case (0x34<<3)|4: assert(false);break;
+        case (0x34<<3)|5: assert(false);break;
+        case (0x34<<3)|6: assert(false);break;
+        case (0x34<<3)|7: assert(false);break;
+    /* AND zp,X */
+        case (0x35<<3)|0: _SA(c->PC++);break;
+        case (0x35<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0x35<<3)|2: _SA((c->AD+c->X)&0x00FF);break;
+        case (0x35<<3)|3: c->A&=_GD();_NZ(c->A);_FETCH();break;
+        case (0x35<<3)|4: assert(false);break;
+        case (0x35<<3)|5: assert(false);break;
+        case (0x35<<3)|6: assert(false);break;
+        case (0x35<<3)|7: assert(false);break;
+    /* ROL zp,X */
+        case (0x36<<3)|0: _SA(c->PC++);break;
+        case (0x36<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0x36<<3)|2: _SA((c->AD+c->X)&0x00FF);break;
+        case (0x36<<3)|3: c->AD=_GD();_WR();break;
+        case (0x36<<3)|4: _SD(_m65c02_rol(c,c->AD));_WR();break;
+        case (0x36<<3)|5: _FETCH();break;
+        case (0x36<<3)|6: assert(false);break;
+        case (0x36<<3)|7: assert(false);break;
+    /* RMB3 zp */
+        case (0x37<<3)|0: _SA(c->PC++);break;
+        case (0x37<<3)|1: _SA(_GD());break;
+        case (0x37<<3)|2: _SD(_GD()&(~(1<<3)));_WR();break;
+        case (0x37<<3)|3: _FETCH();break;
+        case (0x37<<3)|4: assert(false);break;
+        case (0x37<<3)|5: assert(false);break;
+        case (0x37<<3)|6: assert(false);break;
+        case (0x37<<3)|7: assert(false);break;
+    /* SEC  */
+        case (0x38<<3)|0: _SA(c->PC);break;
+        case (0x38<<3)|1: c->P|=0x1;_FETCH();break;
+        case (0x38<<3)|2: assert(false);break;
+        case (0x38<<3)|3: assert(false);break;
+        case (0x38<<3)|4: assert(false);break;
+        case (0x38<<3)|5: assert(false);break;
+        case (0x38<<3)|6: assert(false);break;
+        case (0x38<<3)|7: assert(false);break;
+    /* AND abs,Y */
+        case (0x39<<3)|0: _SA(c->PC++);break;
+        case (0x39<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x39<<3)|2: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->Y)&0xFF));c->IR+=(~((c->AD>>8)-((c->AD+c->Y)>>8)))&1;break;
+        case (0x39<<3)|3: _SA(c->AD+c->Y);break;
+        case (0x39<<3)|4: c->A&=_GD();_NZ(c->A);_FETCH();break;
+        case (0x39<<3)|5: assert(false);break;
+        case (0x39<<3)|6: assert(false);break;
+        case (0x39<<3)|7: assert(false);break;
+    /* DEC A  */
+        case (0x3A<<3)|0: _SA(c->PC);break;
+        case (0x3A<<3)|1: c->A--;_NZ(c->A);_FETCH();break;
+        case (0x3A<<3)|2: assert(false);break;
+        case (0x3A<<3)|3: assert(false);break;
+        case (0x3A<<3)|4: assert(false);break;
+        case (0x3A<<3)|5: assert(false);break;
+        case (0x3A<<3)|6: assert(false);break;
+        case (0x3A<<3)|7: assert(false);break;
+    /* NOP abs,Y */
+        case (0x3B<<3)|0: _SA(c->PC);break;
+        case (0x3B<<3)|1: _FETCH();break;
+        case (0x3B<<3)|2: assert(false);break;
+        case (0x3B<<3)|3: assert(false);break;
+        case (0x3B<<3)|4: assert(false);break;
+        case (0x3B<<3)|5: assert(false);break;
+        case (0x3B<<3)|6: assert(false);break;
+        case (0x3B<<3)|7: assert(false);break;
+    /* BIT abs,X */
+        case (0x3C<<3)|0: _SA(c->PC++);break;
+        case (0x3C<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x3C<<3)|2: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->X)&0xFF));c->IR+=(~((c->AD>>8)-((c->AD+c->X)>>8)))&1;break;
+        case (0x3C<<3)|3: _SA(c->AD+c->X);break;
+        case (0x3C<<3)|4: _m65c02_bit(c,_GD());_FETCH();break;
+        case (0x3C<<3)|5: assert(false);break;
+        case (0x3C<<3)|6: assert(false);break;
+        case (0x3C<<3)|7: assert(false);break;
+    /* AND abs,X */
+        case (0x3D<<3)|0: _SA(c->PC++);break;
+        case (0x3D<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x3D<<3)|2: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->X)&0xFF));c->IR+=(~((c->AD>>8)-((c->AD+c->X)>>8)))&1;break;
+        case (0x3D<<3)|3: _SA(c->AD+c->X);break;
+        case (0x3D<<3)|4: c->A&=_GD();_NZ(c->A);_FETCH();break;
+        case (0x3D<<3)|5: assert(false);break;
+        case (0x3D<<3)|6: assert(false);break;
+        case (0x3D<<3)|7: assert(false);break;
+    /* ROL abs,X */
+        case (0x3E<<3)|0: _SA(c->PC++);break;
+        case (0x3E<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x3E<<3)|2: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->X)&0xFF));break;
+        case (0x3E<<3)|3: _SA(c->AD+c->X);break;
+        case (0x3E<<3)|4: c->AD=_GD();_WR();break;
+        case (0x3E<<3)|5: _SD(_m65c02_rol(c,c->AD));_WR();break;
+        case (0x3E<<3)|6: _FETCH();break;
+        case (0x3E<<3)|7: assert(false);break;
+    /* BBR3 zp,rel */
+        case (0x3F<<3)|0: _SA(c->PC++);break;
+        case (0x3F<<3)|1: _SA(_GD());break;
+        case (0x3F<<3)|2: c->AD=_GD();_SA(c->PC++);break;
+        case (0x3F<<3)|3: if(!(c->AD&(1<<3))){c->PC=c->PC+(int8_t)_GD();_FETCH();};_FETCH();break;
+        case (0x3F<<3)|4: assert(false);break;
+        case (0x3F<<3)|5: assert(false);break;
+        case (0x3F<<3)|6: assert(false);break;
+        case (0x3F<<3)|7: assert(false);break;
+    /* RTI  */
+        case (0x40<<3)|0: _SA(c->PC);break;
+        case (0x40<<3)|1: _SA(0x0100|c->S++);break;
+        case (0x40<<3)|2: _SA(0x0100|c->S++);break;
+        case (0x40<<3)|3: _SA(0x0100|c->S++);c->P=(_GD()|M65C02_BF)&~M65C02_XF;break;
+        case (0x40<<3)|4: _SA(0x0100|c->S);c->AD=_GD();break;
+        case (0x40<<3)|5: c->PC=(_GD()<<8)|c->AD;_FETCH();break;
+        case (0x40<<3)|6: assert(false);break;
+        case (0x40<<3)|7: assert(false);break;
+    /* EOR (zp,X) */
+        case (0x41<<3)|0: _SA(c->PC++);break;
+        case (0x41<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0x41<<3)|2: c->AD=(c->AD+c->X)&0xFF;_SA(c->AD);break;
+        case (0x41<<3)|3: _SA((c->AD+1)&0xFF);c->AD=_GD();break;
+        case (0x41<<3)|4: _SA((_GD()<<8)|c->AD);break;
+        case (0x41<<3)|5: c->A^=_GD();_NZ(c->A);_FETCH();break;
+        case (0x41<<3)|6: assert(false);break;
+        case (0x41<<3)|7: assert(false);break;
+    /* LDD # */
+        case (0x42<<3)|0: _SA(c->PC++);break;
+        case (0x42<<3)|1: _FETCH();break;
+        case (0x42<<3)|2: assert(false);break;
+        case (0x42<<3)|3: assert(false);break;
+        case (0x42<<3)|4: assert(false);break;
+        case (0x42<<3)|5: assert(false);break;
+        case (0x42<<3)|6: assert(false);break;
+        case (0x42<<3)|7: assert(false);break;
+    /* NOP (zp,X) */
+        case (0x43<<3)|0: _SA(c->PC);break;
+        case (0x43<<3)|1: _FETCH();break;
+        case (0x43<<3)|2: assert(false);break;
+        case (0x43<<3)|3: assert(false);break;
+        case (0x43<<3)|4: assert(false);break;
+        case (0x43<<3)|5: assert(false);break;
+        case (0x43<<3)|6: assert(false);break;
+        case (0x43<<3)|7: assert(false);break;
+    /* LDD zp */
+        case (0x44<<3)|0: _SA(c->PC++);break;
+        case (0x44<<3)|1: _SA(_GD());break;
+        case (0x44<<3)|2: _FETCH();break;
+        case (0x44<<3)|3: assert(false);break;
+        case (0x44<<3)|4: assert(false);break;
+        case (0x44<<3)|5: assert(false);break;
+        case (0x44<<3)|6: assert(false);break;
+        case (0x44<<3)|7: assert(false);break;
+    /* EOR zp */
+        case (0x45<<3)|0: _SA(c->PC++);break;
+        case (0x45<<3)|1: _SA(_GD());break;
+        case (0x45<<3)|2: c->A^=_GD();_NZ(c->A);_FETCH();break;
+        case (0x45<<3)|3: assert(false);break;
+        case (0x45<<3)|4: assert(false);break;
+        case (0x45<<3)|5: assert(false);break;
+        case (0x45<<3)|6: assert(false);break;
+        case (0x45<<3)|7: assert(false);break;
+    /* LSR zp */
+        case (0x46<<3)|0: _SA(c->PC++);break;
+        case (0x46<<3)|1: _SA(_GD());break;
+        case (0x46<<3)|2: c->AD=_GD();_WR();break;
+        case (0x46<<3)|3: _SD(_m65c02_lsr(c,c->AD));_WR();break;
+        case (0x46<<3)|4: _FETCH();break;
+        case (0x46<<3)|5: assert(false);break;
+        case (0x46<<3)|6: assert(false);break;
+        case (0x46<<3)|7: assert(false);break;
+    /* RMB4 zp */
+        case (0x47<<3)|0: _SA(c->PC++);break;
+        case (0x47<<3)|1: _SA(_GD());break;
+        case (0x47<<3)|2: _SD(_GD()&(~(1<<4)));_WR();break;
+        case (0x47<<3)|3: _FETCH();break;
+        case (0x47<<3)|4: assert(false);break;
+        case (0x47<<3)|5: assert(false);break;
+        case (0x47<<3)|6: assert(false);break;
+        case (0x47<<3)|7: assert(false);break;
+    /* PHA  */
+        case (0x48<<3)|0: _SA(c->PC);break;
+        case (0x48<<3)|1: _SAD(0x0100|c->S--,c->A);_WR();break;
+        case (0x48<<3)|2: _FETCH();break;
+        case (0x48<<3)|3: assert(false);break;
+        case (0x48<<3)|4: assert(false);break;
+        case (0x48<<3)|5: assert(false);break;
+        case (0x48<<3)|6: assert(false);break;
+        case (0x48<<3)|7: assert(false);break;
+    /* EOR # */
+        case (0x49<<3)|0: _SA(c->PC++);break;
+        case (0x49<<3)|1: c->A^=_GD();_NZ(c->A);_FETCH();break;
+        case (0x49<<3)|2: assert(false);break;
+        case (0x49<<3)|3: assert(false);break;
+        case (0x49<<3)|4: assert(false);break;
+        case (0x49<<3)|5: assert(false);break;
+        case (0x49<<3)|6: assert(false);break;
+        case (0x49<<3)|7: assert(false);break;
+    /* LSRA  */
+        case (0x4A<<3)|0: _SA(c->PC);break;
+        case (0x4A<<3)|1: c->A=_m65c02_lsr(c,c->A);_FETCH();break;
+        case (0x4A<<3)|2: assert(false);break;
+        case (0x4A<<3)|3: assert(false);break;
+        case (0x4A<<3)|4: assert(false);break;
+        case (0x4A<<3)|5: assert(false);break;
+        case (0x4A<<3)|6: assert(false);break;
+        case (0x4A<<3)|7: assert(false);break;
+    /* NOP # */
+        case (0x4B<<3)|0: _SA(c->PC);break;
+        case (0x4B<<3)|1: _FETCH();break;
+        case (0x4B<<3)|2: assert(false);break;
+        case (0x4B<<3)|3: assert(false);break;
+        case (0x4B<<3)|4: assert(false);break;
+        case (0x4B<<3)|5: assert(false);break;
+        case (0x4B<<3)|6: assert(false);break;
+        case (0x4B<<3)|7: assert(false);break;
+    /* JMP  */
+        case (0x4C<<3)|0: _SA(c->PC++);break;
+        case (0x4C<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x4C<<3)|2: c->PC=(_GD()<<8)|c->AD;_FETCH();break;
+        case (0x4C<<3)|3: assert(false);break;
+        case (0x4C<<3)|4: assert(false);break;
+        case (0x4C<<3)|5: assert(false);break;
+        case (0x4C<<3)|6: assert(false);break;
+        case (0x4C<<3)|7: assert(false);break;
+    /* EOR abs */
+        case (0x4D<<3)|0: _SA(c->PC++);break;
+        case (0x4D<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x4D<<3)|2: _SA((_GD()<<8)|c->AD);break;
+        case (0x4D<<3)|3: c->A^=_GD();_NZ(c->A);_FETCH();break;
+        case (0x4D<<3)|4: assert(false);break;
+        case (0x4D<<3)|5: assert(false);break;
+        case (0x4D<<3)|6: assert(false);break;
+        case (0x4D<<3)|7: assert(false);break;
+    /* LSR abs */
+        case (0x4E<<3)|0: _SA(c->PC++);break;
+        case (0x4E<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x4E<<3)|2: _SA((_GD()<<8)|c->AD);break;
+        case (0x4E<<3)|3: c->AD=_GD();_WR();break;
+        case (0x4E<<3)|4: _SD(_m65c02_lsr(c,c->AD));_WR();break;
+        case (0x4E<<3)|5: _FETCH();break;
+        case (0x4E<<3)|6: assert(false);break;
+        case (0x4E<<3)|7: assert(false);break;
+    /* BBR4 zp,rel */
+        case (0x4F<<3)|0: _SA(c->PC++);break;
+        case (0x4F<<3)|1: _SA(_GD());break;
+        case (0x4F<<3)|2: c->AD=_GD();_SA(c->PC++);break;
+        case (0x4F<<3)|3: if(!(c->AD&(1<<4))){c->PC=c->PC+(int8_t)_GD();_FETCH();};_FETCH();break;
+        case (0x4F<<3)|4: assert(false);break;
+        case (0x4F<<3)|5: assert(false);break;
+        case (0x4F<<3)|6: assert(false);break;
+        case (0x4F<<3)|7: assert(false);break;
+    /* BVC # */
+        case (0x50<<3)|0: _SA(c->PC++);break;
+        case (0x50<<3)|1: _SA(c->PC);c->AD=c->PC+(int8_t)_GD();if((c->P&0x40)!=0x0){_FETCH();};break;
+        case (0x50<<3)|2: _SA((c->PC&0xFF00)|(c->AD&0x00FF));if((c->AD&0xFF00)==(c->PC&0xFF00)){c->PC=c->AD;c->irq_pip>>=1;c->nmi_pip>>=1;_FETCH();};break;
+        case (0x50<<3)|3: c->PC=c->AD;_FETCH();break;
+        case (0x50<<3)|4: assert(false);break;
+        case (0x50<<3)|5: assert(false);break;
+        case (0x50<<3)|6: assert(false);break;
+        case (0x50<<3)|7: assert(false);break;
+    /* EOR (zp),Y */
+        case (0x51<<3)|0: _SA(c->PC++);break;
+        case (0x51<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0x51<<3)|2: _SA((c->AD+1)&0xFF);c->AD=_GD();break;
+        case (0x51<<3)|3: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->Y)&0xFF));c->IR+=(~((c->AD>>8)-((c->AD+c->Y)>>8)))&1;break;
+        case (0x51<<3)|4: _SA(c->AD+c->Y);break;
+        case (0x51<<3)|5: c->A^=_GD();_NZ(c->A);_FETCH();break;
+        case (0x51<<3)|6: assert(false);break;
+        case (0x51<<3)|7: assert(false);break;
+    /* EOR (zp) */
+        case (0x52<<3)|0: _SA(c->PC++);break;
+        case (0x52<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0x52<<3)|2: _SA((c->AD+1)&0xFF);c->AD=_GD();break;
+        case (0x52<<3)|3: _SA((_GD()<<8)|c->AD);break;
+        case (0x52<<3)|4: c->A^=_GD();_NZ(c->A);_FETCH();break;
+        case (0x52<<3)|5: assert(false);break;
+        case (0x52<<3)|6: assert(false);break;
+        case (0x52<<3)|7: assert(false);break;
+    /* NOP (zp),Y */
+        case (0x53<<3)|0: _SA(c->PC);break;
+        case (0x53<<3)|1: _FETCH();break;
+        case (0x53<<3)|2: assert(false);break;
+        case (0x53<<3)|3: assert(false);break;
+        case (0x53<<3)|4: assert(false);break;
+        case (0x53<<3)|5: assert(false);break;
+        case (0x53<<3)|6: assert(false);break;
+        case (0x53<<3)|7: assert(false);break;
+    /* LDD zp,X */
+        case (0x54<<3)|0: _SA(c->PC++);break;
+        case (0x54<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0x54<<3)|2: _SA((c->AD+c->X)&0x00FF);break;
+        case (0x54<<3)|3: _FETCH();break;
+        case (0x54<<3)|4: assert(false);break;
+        case (0x54<<3)|5: assert(false);break;
+        case (0x54<<3)|6: assert(false);break;
+        case (0x54<<3)|7: assert(false);break;
+    /* EOR zp,X */
+        case (0x55<<3)|0: _SA(c->PC++);break;
+        case (0x55<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0x55<<3)|2: _SA((c->AD+c->X)&0x00FF);break;
+        case (0x55<<3)|3: c->A^=_GD();_NZ(c->A);_FETCH();break;
+        case (0x55<<3)|4: assert(false);break;
+        case (0x55<<3)|5: assert(false);break;
+        case (0x55<<3)|6: assert(false);break;
+        case (0x55<<3)|7: assert(false);break;
+    /* LSR zp,X */
+        case (0x56<<3)|0: _SA(c->PC++);break;
+        case (0x56<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0x56<<3)|2: _SA((c->AD+c->X)&0x00FF);break;
+        case (0x56<<3)|3: c->AD=_GD();_WR();break;
+        case (0x56<<3)|4: _SD(_m65c02_lsr(c,c->AD));_WR();break;
+        case (0x56<<3)|5: _FETCH();break;
+        case (0x56<<3)|6: assert(false);break;
+        case (0x56<<3)|7: assert(false);break;
+    /* RMB5 zp */
+        case (0x57<<3)|0: _SA(c->PC++);break;
+        case (0x57<<3)|1: _SA(_GD());break;
+        case (0x57<<3)|2: _SD(_GD()&(~(1<<5)));_WR();break;
+        case (0x57<<3)|3: _FETCH();break;
+        case (0x57<<3)|4: assert(false);break;
+        case (0x57<<3)|5: assert(false);break;
+        case (0x57<<3)|6: assert(false);break;
+        case (0x57<<3)|7: assert(false);break;
+    /* CLI  */
+        case (0x58<<3)|0: _SA(c->PC);break;
+        case (0x58<<3)|1: c->P&=~0x4;_FETCH();break;
+        case (0x58<<3)|2: assert(false);break;
+        case (0x58<<3)|3: assert(false);break;
+        case (0x58<<3)|4: assert(false);break;
+        case (0x58<<3)|5: assert(false);break;
+        case (0x58<<3)|6: assert(false);break;
+        case (0x58<<3)|7: assert(false);break;
+    /* EOR abs,Y */
+        case (0x59<<3)|0: _SA(c->PC++);break;
+        case (0x59<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x59<<3)|2: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->Y)&0xFF));c->IR+=(~((c->AD>>8)-((c->AD+c->Y)>>8)))&1;break;
+        case (0x59<<3)|3: _SA(c->AD+c->Y);break;
+        case (0x59<<3)|4: c->A^=_GD();_NZ(c->A);_FETCH();break;
+        case (0x59<<3)|5: assert(false);break;
+        case (0x59<<3)|6: assert(false);break;
+        case (0x59<<3)|7: assert(false);break;
+    /* PHY  */
+        case (0x5A<<3)|0: _SA(c->PC);break;
+        case (0x5A<<3)|1: _SAD(0x0100|c->S--,c->Y);_WR();break;
+        case (0x5A<<3)|2: _FETCH();break;
+        case (0x5A<<3)|3: assert(false);break;
+        case (0x5A<<3)|4: assert(false);break;
+        case (0x5A<<3)|5: assert(false);break;
+        case (0x5A<<3)|6: assert(false);break;
+        case (0x5A<<3)|7: assert(false);break;
+    /* NOP abs,Y */
+        case (0x5B<<3)|0: _SA(c->PC);break;
+        case (0x5B<<3)|1: _FETCH();break;
+        case (0x5B<<3)|2: assert(false);break;
+        case (0x5B<<3)|3: assert(false);break;
+        case (0x5B<<3)|4: assert(false);break;
+        case (0x5B<<3)|5: assert(false);break;
+        case (0x5B<<3)|6: assert(false);break;
+        case (0x5B<<3)|7: assert(false);break;
+    /* LDD abs,X */
+        case (0x5C<<3)|0: _SA(c->PC++);break;
+        case (0x5C<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x5C<<3)|2: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->X)&0xFF));c->IR+=(~((c->AD>>8)-((c->AD+c->X)>>8)))&1;break;
+        case (0x5C<<3)|3: _SA(c->AD+c->X);break;
+        case (0x5C<<3)|4: _FETCH();break;
+        case (0x5C<<3)|5: assert(false);break;
+        case (0x5C<<3)|6: assert(false);break;
+        case (0x5C<<3)|7: assert(false);break;
+    /* EOR abs,X */
+        case (0x5D<<3)|0: _SA(c->PC++);break;
+        case (0x5D<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x5D<<3)|2: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->X)&0xFF));c->IR+=(~((c->AD>>8)-((c->AD+c->X)>>8)))&1;break;
+        case (0x5D<<3)|3: _SA(c->AD+c->X);break;
+        case (0x5D<<3)|4: c->A^=_GD();_NZ(c->A);_FETCH();break;
+        case (0x5D<<3)|5: assert(false);break;
+        case (0x5D<<3)|6: assert(false);break;
+        case (0x5D<<3)|7: assert(false);break;
+    /* LSR abs,X */
+        case (0x5E<<3)|0: _SA(c->PC++);break;
+        case (0x5E<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x5E<<3)|2: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->X)&0xFF));break;
+        case (0x5E<<3)|3: _SA(c->AD+c->X);break;
+        case (0x5E<<3)|4: c->AD=_GD();_WR();break;
+        case (0x5E<<3)|5: _SD(_m65c02_lsr(c,c->AD));_WR();break;
+        case (0x5E<<3)|6: _FETCH();break;
+        case (0x5E<<3)|7: assert(false);break;
+    /* BBR5 zp,rel */
+        case (0x5F<<3)|0: _SA(c->PC++);break;
+        case (0x5F<<3)|1: _SA(_GD());break;
+        case (0x5F<<3)|2: c->AD=_GD();_SA(c->PC++);break;
+        case (0x5F<<3)|3: if(!(c->AD&(1<<5))){c->PC=c->PC+(int8_t)_GD();_FETCH();};_FETCH();break;
+        case (0x5F<<3)|4: assert(false);break;
+        case (0x5F<<3)|5: assert(false);break;
+        case (0x5F<<3)|6: assert(false);break;
+        case (0x5F<<3)|7: assert(false);break;
+    /* RTS  */
+        case (0x60<<3)|0: _SA(c->PC);break;
+        case (0x60<<3)|1: _SA(0x0100|c->S++);break;
+        case (0x60<<3)|2: _SA(0x0100|c->S++);break;
+        case (0x60<<3)|3: _SA(0x0100|c->S);c->AD=_GD();break;
+        case (0x60<<3)|4: c->PC=(_GD()<<8)|c->AD;_SA(c->PC++);break;
+        case (0x60<<3)|5: _FETCH();break;
+        case (0x60<<3)|6: assert(false);break;
+        case (0x60<<3)|7: assert(false);break;
+    /* ADC (zp,X) */
+        case (0x61<<3)|0: _SA(c->PC++);break;
+        case (0x61<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0x61<<3)|2: c->AD=(c->AD+c->X)&0xFF;_SA(c->AD);break;
+        case (0x61<<3)|3: _SA((c->AD+1)&0xFF);c->AD=_GD();break;
+        case (0x61<<3)|4: _SA((_GD()<<8)|c->AD);break;
+        case (0x61<<3)|5: _m65c02_adc(c,_GD());if(c->P&M65C02_DF){c->P=((c->P&~(M65C02_NF|M65C02_ZF))|((c->A&0xFF)?(c->A&M65C02_NF):M65C02_ZF));};_FETCH();break;
+        case (0x61<<3)|6: assert(false);break;
+        case (0x61<<3)|7: assert(false);break;
+    /* LDD # */
+        case (0x62<<3)|0: _SA(c->PC++);break;
+        case (0x62<<3)|1: _FETCH();break;
+        case (0x62<<3)|2: assert(false);break;
+        case (0x62<<3)|3: assert(false);break;
+        case (0x62<<3)|4: assert(false);break;
+        case (0x62<<3)|5: assert(false);break;
+        case (0x62<<3)|6: assert(false);break;
+        case (0x62<<3)|7: assert(false);break;
+    /* NOP (zp,X) */
+        case (0x63<<3)|0: _SA(c->PC);break;
+        case (0x63<<3)|1: _FETCH();break;
+        case (0x63<<3)|2: assert(false);break;
+        case (0x63<<3)|3: assert(false);break;
+        case (0x63<<3)|4: assert(false);break;
+        case (0x63<<3)|5: assert(false);break;
+        case (0x63<<3)|6: assert(false);break;
+        case (0x63<<3)|7: assert(false);break;
+    /* STZ zp */
+        case (0x64<<3)|0: _SA(c->PC++);break;
+        case (0x64<<3)|1: _SA(_GD());_SD(0);_WR();break;
+        case (0x64<<3)|2: _FETCH();break;
+        case (0x64<<3)|3: assert(false);break;
+        case (0x64<<3)|4: assert(false);break;
+        case (0x64<<3)|5: assert(false);break;
+        case (0x64<<3)|6: assert(false);break;
+        case (0x64<<3)|7: assert(false);break;
+    /* ADC zp */
+        case (0x65<<3)|0: _SA(c->PC++);break;
+        case (0x65<<3)|1: _SA(_GD());break;
+        case (0x65<<3)|2: _m65c02_adc(c,_GD());if(c->P&M65C02_DF){c->P=((c->P&~(M65C02_NF|M65C02_ZF))|((c->A&0xFF)?(c->A&M65C02_NF):M65C02_ZF));};_FETCH();break;
+        case (0x65<<3)|3: assert(false);break;
+        case (0x65<<3)|4: assert(false);break;
+        case (0x65<<3)|5: assert(false);break;
+        case (0x65<<3)|6: assert(false);break;
+        case (0x65<<3)|7: assert(false);break;
+    /* ROR zp */
+        case (0x66<<3)|0: _SA(c->PC++);break;
+        case (0x66<<3)|1: _SA(_GD());break;
+        case (0x66<<3)|2: c->AD=_GD();_WR();break;
+        case (0x66<<3)|3: _SD(_m65c02_ror(c,c->AD));_WR();break;
+        case (0x66<<3)|4: _FETCH();break;
+        case (0x66<<3)|5: assert(false);break;
+        case (0x66<<3)|6: assert(false);break;
+        case (0x66<<3)|7: assert(false);break;
+    /* RMB6 zp */
+        case (0x67<<3)|0: _SA(c->PC++);break;
+        case (0x67<<3)|1: _SA(_GD());break;
+        case (0x67<<3)|2: _SD(_GD()&(~(1<<6)));_WR();break;
+        case (0x67<<3)|3: _FETCH();break;
+        case (0x67<<3)|4: assert(false);break;
+        case (0x67<<3)|5: assert(false);break;
+        case (0x67<<3)|6: assert(false);break;
+        case (0x67<<3)|7: assert(false);break;
+    /* PLA  */
+        case (0x68<<3)|0: _SA(c->PC);break;
+        case (0x68<<3)|1: _SA(0x0100|c->S++);break;
+        case (0x68<<3)|2: _SA(0x0100|c->S);break;
+        case (0x68<<3)|3: c->A=_GD();_NZ(c->A);_FETCH();break;
+        case (0x68<<3)|4: assert(false);break;
+        case (0x68<<3)|5: assert(false);break;
+        case (0x68<<3)|6: assert(false);break;
+        case (0x68<<3)|7: assert(false);break;
+    /* ADC # */
+        case (0x69<<3)|0: _SA(c->PC++);break;
+        case (0x69<<3)|1: _m65c02_adc(c,_GD());if(c->P&M65C02_DF){c->P=((c->P&~(M65C02_NF|M65C02_ZF))|((c->A&0xFF)?(c->A&M65C02_NF):M65C02_ZF));};_FETCH();break;
+        case (0x69<<3)|2: assert(false);break;
+        case (0x69<<3)|3: assert(false);break;
+        case (0x69<<3)|4: assert(false);break;
+        case (0x69<<3)|5: assert(false);break;
+        case (0x69<<3)|6: assert(false);break;
+        case (0x69<<3)|7: assert(false);break;
+    /* RORA  */
+        case (0x6A<<3)|0: _SA(c->PC);break;
+        case (0x6A<<3)|1: c->A=_m65c02_ror(c,c->A);_FETCH();break;
+        case (0x6A<<3)|2: assert(false);break;
+        case (0x6A<<3)|3: assert(false);break;
+        case (0x6A<<3)|4: assert(false);break;
+        case (0x6A<<3)|5: assert(false);break;
+        case (0x6A<<3)|6: assert(false);break;
+        case (0x6A<<3)|7: assert(false);break;
+    /* NOP # */
+        case (0x6B<<3)|0: _SA(c->PC);break;
+        case (0x6B<<3)|1: _FETCH();break;
+        case (0x6B<<3)|2: assert(false);break;
+        case (0x6B<<3)|3: assert(false);break;
+        case (0x6B<<3)|4: assert(false);break;
+        case (0x6B<<3)|5: assert(false);break;
+        case (0x6B<<3)|6: assert(false);break;
+        case (0x6B<<3)|7: assert(false);break;
+    /* JMPI  */
+        case (0x6C<<3)|0: _SA(c->PC++);break;
+        case (0x6C<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x6C<<3)|2: c->AD|=_GD()<<8;_SA(c->AD);break;
+        case (0x6C<<3)|3: _SA(c->AD+1);c->AD=_GD();break;
+        case (0x6C<<3)|4: c->PC=(_GD()<<8)|c->AD;_FETCH();break;
+        case (0x6C<<3)|5: assert(false);break;
+        case (0x6C<<3)|6: assert(false);break;
+        case (0x6C<<3)|7: assert(false);break;
+    /* ADC abs */
+        case (0x6D<<3)|0: _SA(c->PC++);break;
+        case (0x6D<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x6D<<3)|2: _SA((_GD()<<8)|c->AD);break;
+        case (0x6D<<3)|3: _m65c02_adc(c,_GD());if(c->P&M65C02_DF){c->P=((c->P&~(M65C02_NF|M65C02_ZF))|((c->A&0xFF)?(c->A&M65C02_NF):M65C02_ZF));};_FETCH();break;
+        case (0x6D<<3)|4: assert(false);break;
+        case (0x6D<<3)|5: assert(false);break;
+        case (0x6D<<3)|6: assert(false);break;
+        case (0x6D<<3)|7: assert(false);break;
+    /* ROR abs */
+        case (0x6E<<3)|0: _SA(c->PC++);break;
+        case (0x6E<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x6E<<3)|2: _SA((_GD()<<8)|c->AD);break;
+        case (0x6E<<3)|3: c->AD=_GD();_WR();break;
+        case (0x6E<<3)|4: _SD(_m65c02_ror(c,c->AD));_WR();break;
+        case (0x6E<<3)|5: _FETCH();break;
+        case (0x6E<<3)|6: assert(false);break;
+        case (0x6E<<3)|7: assert(false);break;
+    /* BBR6 zp,rel */
+        case (0x6F<<3)|0: _SA(c->PC++);break;
+        case (0x6F<<3)|1: _SA(_GD());break;
+        case (0x6F<<3)|2: c->AD=_GD();_SA(c->PC++);break;
+        case (0x6F<<3)|3: if(!(c->AD&(1<<6))){c->PC=c->PC+(int8_t)_GD();_FETCH();};_FETCH();break;
+        case (0x6F<<3)|4: assert(false);break;
+        case (0x6F<<3)|5: assert(false);break;
+        case (0x6F<<3)|6: assert(false);break;
+        case (0x6F<<3)|7: assert(false);break;
+    /* BVS # */
+        case (0x70<<3)|0: _SA(c->PC++);break;
+        case (0x70<<3)|1: _SA(c->PC);c->AD=c->PC+(int8_t)_GD();if((c->P&0x40)!=0x40){_FETCH();};break;
+        case (0x70<<3)|2: _SA((c->PC&0xFF00)|(c->AD&0x00FF));if((c->AD&0xFF00)==(c->PC&0xFF00)){c->PC=c->AD;c->irq_pip>>=1;c->nmi_pip>>=1;_FETCH();};break;
+        case (0x70<<3)|3: c->PC=c->AD;_FETCH();break;
+        case (0x70<<3)|4: assert(false);break;
+        case (0x70<<3)|5: assert(false);break;
+        case (0x70<<3)|6: assert(false);break;
+        case (0x70<<3)|7: assert(false);break;
+    /* ADC (zp),Y */
+        case (0x71<<3)|0: _SA(c->PC++);break;
+        case (0x71<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0x71<<3)|2: _SA((c->AD+1)&0xFF);c->AD=_GD();break;
+        case (0x71<<3)|3: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->Y)&0xFF));c->IR+=(~((c->AD>>8)-((c->AD+c->Y)>>8)))&1;break;
+        case (0x71<<3)|4: _SA(c->AD+c->Y);break;
+        case (0x71<<3)|5: _m65c02_adc(c,_GD());if(c->P&M65C02_DF){c->P=((c->P&~(M65C02_NF|M65C02_ZF))|((c->A&0xFF)?(c->A&M65C02_NF):M65C02_ZF));};_FETCH();break;
+        case (0x71<<3)|6: assert(false);break;
+        case (0x71<<3)|7: assert(false);break;
+    /* ADC (zp) */
+        case (0x72<<3)|0: _SA(c->PC++);break;
+        case (0x72<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0x72<<3)|2: _SA((c->AD+1)&0xFF);c->AD=_GD();break;
+        case (0x72<<3)|3: _SA((_GD()<<8)|c->AD);break;
+        case (0x72<<3)|4: _m65c02_adc(c,_GD());if(c->P&M65C02_DF){c->P=((c->P&~(M65C02_NF|M65C02_ZF))|((c->A&0xFF)?(c->A&M65C02_NF):M65C02_ZF));};_FETCH();break;
+        case (0x72<<3)|5: assert(false);break;
+        case (0x72<<3)|6: assert(false);break;
+        case (0x72<<3)|7: assert(false);break;
+    /* NOP (zp),Y */
+        case (0x73<<3)|0: _SA(c->PC);break;
+        case (0x73<<3)|1: _FETCH();break;
+        case (0x73<<3)|2: assert(false);break;
+        case (0x73<<3)|3: assert(false);break;
+        case (0x73<<3)|4: assert(false);break;
+        case (0x73<<3)|5: assert(false);break;
+        case (0x73<<3)|6: assert(false);break;
+        case (0x73<<3)|7: assert(false);break;
+    /* STZ zp,X */
+        case (0x74<<3)|0: _SA(c->PC++);break;
+        case (0x74<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0x74<<3)|2: _SA((c->AD+c->X)&0x00FF);_SD(0);_WR();break;
+        case (0x74<<3)|3: _FETCH();break;
+        case (0x74<<3)|4: assert(false);break;
+        case (0x74<<3)|5: assert(false);break;
+        case (0x74<<3)|6: assert(false);break;
+        case (0x74<<3)|7: assert(false);break;
+    /* ADC zp,X */
+        case (0x75<<3)|0: _SA(c->PC++);break;
+        case (0x75<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0x75<<3)|2: _SA((c->AD+c->X)&0x00FF);break;
+        case (0x75<<3)|3: _m65c02_adc(c,_GD());if(c->P&M65C02_DF){c->P=((c->P&~(M65C02_NF|M65C02_ZF))|((c->A&0xFF)?(c->A&M65C02_NF):M65C02_ZF));};_FETCH();break;
+        case (0x75<<3)|4: assert(false);break;
+        case (0x75<<3)|5: assert(false);break;
+        case (0x75<<3)|6: assert(false);break;
+        case (0x75<<3)|7: assert(false);break;
+    /* ROR zp,X */
+        case (0x76<<3)|0: _SA(c->PC++);break;
+        case (0x76<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0x76<<3)|2: _SA((c->AD+c->X)&0x00FF);break;
+        case (0x76<<3)|3: c->AD=_GD();_WR();break;
+        case (0x76<<3)|4: _SD(_m65c02_ror(c,c->AD));_WR();break;
+        case (0x76<<3)|5: _FETCH();break;
+        case (0x76<<3)|6: assert(false);break;
+        case (0x76<<3)|7: assert(false);break;
+    /* RMB7 zp */
+        case (0x77<<3)|0: _SA(c->PC++);break;
+        case (0x77<<3)|1: _SA(_GD());break;
+        case (0x77<<3)|2: _SD(_GD()&(~(1<<7)));_WR();break;
+        case (0x77<<3)|3: _FETCH();break;
+        case (0x77<<3)|4: assert(false);break;
+        case (0x77<<3)|5: assert(false);break;
+        case (0x77<<3)|6: assert(false);break;
+        case (0x77<<3)|7: assert(false);break;
+    /* SEI  */
+        case (0x78<<3)|0: _SA(c->PC);break;
+        case (0x78<<3)|1: c->P|=0x4;_FETCH();break;
+        case (0x78<<3)|2: assert(false);break;
+        case (0x78<<3)|3: assert(false);break;
+        case (0x78<<3)|4: assert(false);break;
+        case (0x78<<3)|5: assert(false);break;
+        case (0x78<<3)|6: assert(false);break;
+        case (0x78<<3)|7: assert(false);break;
+    /* ADC abs,Y */
+        case (0x79<<3)|0: _SA(c->PC++);break;
+        case (0x79<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x79<<3)|2: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->Y)&0xFF));c->IR+=(~((c->AD>>8)-((c->AD+c->Y)>>8)))&1;break;
+        case (0x79<<3)|3: _SA(c->AD+c->Y);break;
+        case (0x79<<3)|4: _m65c02_adc(c,_GD());if(c->P&M65C02_DF){c->P=((c->P&~(M65C02_NF|M65C02_ZF))|((c->A&0xFF)?(c->A&M65C02_NF):M65C02_ZF));};_FETCH();break;
+        case (0x79<<3)|5: assert(false);break;
+        case (0x79<<3)|6: assert(false);break;
+        case (0x79<<3)|7: assert(false);break;
+    /* PLY  */
+        case (0x7A<<3)|0: _SA(c->PC);break;
+        case (0x7A<<3)|1: _SA(0x0100|c->S++);break;
+        case (0x7A<<3)|2: _SA(0x0100|c->S);break;
+        case (0x7A<<3)|3: c->Y=_GD();_NZ(c->Y);_FETCH();break;
+        case (0x7A<<3)|4: assert(false);break;
+        case (0x7A<<3)|5: assert(false);break;
+        case (0x7A<<3)|6: assert(false);break;
+        case (0x7A<<3)|7: assert(false);break;
+    /* NOP abs,Y */
+        case (0x7B<<3)|0: _SA(c->PC);break;
+        case (0x7B<<3)|1: _FETCH();break;
+        case (0x7B<<3)|2: assert(false);break;
+        case (0x7B<<3)|3: assert(false);break;
+        case (0x7B<<3)|4: assert(false);break;
+        case (0x7B<<3)|5: assert(false);break;
+        case (0x7B<<3)|6: assert(false);break;
+        case (0x7B<<3)|7: assert(false);break;
+    /* JMPIX (abs,X) */
+        case (0x7C<<3)|0: _SA(c->PC++);break;
+        case (0x7C<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x7C<<3)|2: c->AD|=_GD()<<8;c->AD+=c->X;_SA(c->AD);break;
+        case (0x7C<<3)|3: _SA(c->AD+1);c->AD=_GD();break;
+        case (0x7C<<3)|4: c->PC=(_GD()<<8)|c->AD;_FETCH();break;
+        case (0x7C<<3)|5: assert(false);break;
+        case (0x7C<<3)|6: assert(false);break;
+        case (0x7C<<3)|7: assert(false);break;
+    /* ADC abs,X */
+        case (0x7D<<3)|0: _SA(c->PC++);break;
+        case (0x7D<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x7D<<3)|2: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->X)&0xFF));c->IR+=(~((c->AD>>8)-((c->AD+c->X)>>8)))&1;break;
+        case (0x7D<<3)|3: _SA(c->AD+c->X);break;
+        case (0x7D<<3)|4: _m65c02_adc(c,_GD());if(c->P&M65C02_DF){c->P=((c->P&~(M65C02_NF|M65C02_ZF))|((c->A&0xFF)?(c->A&M65C02_NF):M65C02_ZF));};_FETCH();break;
+        case (0x7D<<3)|5: assert(false);break;
+        case (0x7D<<3)|6: assert(false);break;
+        case (0x7D<<3)|7: assert(false);break;
+    /* ROR abs,X */
+        case (0x7E<<3)|0: _SA(c->PC++);break;
+        case (0x7E<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x7E<<3)|2: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->X)&0xFF));break;
+        case (0x7E<<3)|3: _SA(c->AD+c->X);break;
+        case (0x7E<<3)|4: c->AD=_GD();_WR();break;
+        case (0x7E<<3)|5: _SD(_m65c02_ror(c,c->AD));_WR();break;
+        case (0x7E<<3)|6: _FETCH();break;
+        case (0x7E<<3)|7: assert(false);break;
+    /* BBR7 zp,rel */
+        case (0x7F<<3)|0: _SA(c->PC++);break;
+        case (0x7F<<3)|1: _SA(_GD());break;
+        case (0x7F<<3)|2: c->AD=_GD();_SA(c->PC++);break;
+        case (0x7F<<3)|3: if(!(c->AD&(1<<7))){c->PC=c->PC+(int8_t)_GD();_FETCH();};_FETCH();break;
+        case (0x7F<<3)|4: assert(false);break;
+        case (0x7F<<3)|5: assert(false);break;
+        case (0x7F<<3)|6: assert(false);break;
+        case (0x7F<<3)|7: assert(false);break;
+    /* BRA # */
+        case (0x80<<3)|0: _SA(c->PC++);break;
+        case (0x80<<3)|1: _SA(c->PC);c->AD=c->PC+(int8_t)_GD();break;
+        case (0x80<<3)|2: _SA((c->PC&0xFF00)|(c->AD&0x00FF));if((c->AD&0xFF00)==(c->PC&0xFF00)){c->PC=c->AD;c->irq_pip>>=1;c->nmi_pip>>=1;_FETCH();};break;
+        case (0x80<<3)|3: c->PC=c->AD;_FETCH();break;
+        case (0x80<<3)|4: assert(false);break;
+        case (0x80<<3)|5: assert(false);break;
+        case (0x80<<3)|6: assert(false);break;
+        case (0x80<<3)|7: assert(false);break;
+    /* STA (zp,X) */
+        case (0x81<<3)|0: _SA(c->PC++);break;
+        case (0x81<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0x81<<3)|2: c->AD=(c->AD+c->X)&0xFF;_SA(c->AD);break;
+        case (0x81<<3)|3: _SA((c->AD+1)&0xFF);c->AD=_GD();break;
+        case (0x81<<3)|4: _SA((_GD()<<8)|c->AD);_SD(c->A);_WR();break;
+        case (0x81<<3)|5: _FETCH();break;
+        case (0x81<<3)|6: assert(false);break;
+        case (0x81<<3)|7: assert(false);break;
+    /* LDD # */
+        case (0x82<<3)|0: _SA(c->PC++);break;
+        case (0x82<<3)|1: _FETCH();break;
+        case (0x82<<3)|2: assert(false);break;
+        case (0x82<<3)|3: assert(false);break;
+        case (0x82<<3)|4: assert(false);break;
+        case (0x82<<3)|5: assert(false);break;
+        case (0x82<<3)|6: assert(false);break;
+        case (0x82<<3)|7: assert(false);break;
+    /* NOP (zp,X) */
+        case (0x83<<3)|0: _SA(c->PC);break;
+        case (0x83<<3)|1: _FETCH();break;
+        case (0x83<<3)|2: assert(false);break;
+        case (0x83<<3)|3: assert(false);break;
+        case (0x83<<3)|4: assert(false);break;
+        case (0x83<<3)|5: assert(false);break;
+        case (0x83<<3)|6: assert(false);break;
+        case (0x83<<3)|7: assert(false);break;
+    /* STY zp */
+        case (0x84<<3)|0: _SA(c->PC++);break;
+        case (0x84<<3)|1: _SA(_GD());_SD(c->Y);_WR();break;
+        case (0x84<<3)|2: _FETCH();break;
+        case (0x84<<3)|3: assert(false);break;
+        case (0x84<<3)|4: assert(false);break;
+        case (0x84<<3)|5: assert(false);break;
+        case (0x84<<3)|6: assert(false);break;
+        case (0x84<<3)|7: assert(false);break;
+    /* STA zp */
+        case (0x85<<3)|0: _SA(c->PC++);break;
+        case (0x85<<3)|1: _SA(_GD());_SD(c->A);_WR();break;
+        case (0x85<<3)|2: _FETCH();break;
+        case (0x85<<3)|3: assert(false);break;
+        case (0x85<<3)|4: assert(false);break;
+        case (0x85<<3)|5: assert(false);break;
+        case (0x85<<3)|6: assert(false);break;
+        case (0x85<<3)|7: assert(false);break;
+    /* STX zp */
+        case (0x86<<3)|0: _SA(c->PC++);break;
+        case (0x86<<3)|1: _SA(_GD());_SD(c->X);_WR();break;
+        case (0x86<<3)|2: _FETCH();break;
+        case (0x86<<3)|3: assert(false);break;
+        case (0x86<<3)|4: assert(false);break;
+        case (0x86<<3)|5: assert(false);break;
+        case (0x86<<3)|6: assert(false);break;
+        case (0x86<<3)|7: assert(false);break;
+    /* SMB0 zp */
+        case (0x87<<3)|0: _SA(c->PC++);break;
+        case (0x87<<3)|1: _SA(_GD());break;
+        case (0x87<<3)|2: _SD(_GD()|(1<<0));_WR();break;
+        case (0x87<<3)|3: _FETCH();break;
+        case (0x87<<3)|4: assert(false);break;
+        case (0x87<<3)|5: assert(false);break;
+        case (0x87<<3)|6: assert(false);break;
+        case (0x87<<3)|7: assert(false);break;
+    /* DEY  */
+        case (0x88<<3)|0: _SA(c->PC);break;
+        case (0x88<<3)|1: c->Y--;_NZ(c->Y);_FETCH();break;
+        case (0x88<<3)|2: assert(false);break;
+        case (0x88<<3)|3: assert(false);break;
+        case (0x88<<3)|4: assert(false);break;
+        case (0x88<<3)|5: assert(false);break;
+        case (0x88<<3)|6: assert(false);break;
+        case (0x88<<3)|7: assert(false);break;
+    /* BIT # */
+        case (0x89<<3)|0: _SA(c->PC++);break;
+        case (0x89<<3)|1: c->P&=~M65C02_ZF;if(!(c->A&_GD())){c->P|=M65C02_ZF;};_FETCH();break;
+        case (0x89<<3)|2: assert(false);break;
+        case (0x89<<3)|3: assert(false);break;
+        case (0x89<<3)|4: assert(false);break;
+        case (0x89<<3)|5: assert(false);break;
+        case (0x89<<3)|6: assert(false);break;
+        case (0x89<<3)|7: assert(false);break;
+    /* TXA  */
+        case (0x8A<<3)|0: _SA(c->PC);break;
+        case (0x8A<<3)|1: c->A=c->X;_NZ(c->A);_FETCH();break;
+        case (0x8A<<3)|2: assert(false);break;
+        case (0x8A<<3)|3: assert(false);break;
+        case (0x8A<<3)|4: assert(false);break;
+        case (0x8A<<3)|5: assert(false);break;
+        case (0x8A<<3)|6: assert(false);break;
+        case (0x8A<<3)|7: assert(false);break;
+    /* NOP # */
+        case (0x8B<<3)|0: _SA(c->PC);break;
+        case (0x8B<<3)|1: _FETCH();break;
+        case (0x8B<<3)|2: assert(false);break;
+        case (0x8B<<3)|3: assert(false);break;
+        case (0x8B<<3)|4: assert(false);break;
+        case (0x8B<<3)|5: assert(false);break;
+        case (0x8B<<3)|6: assert(false);break;
+        case (0x8B<<3)|7: assert(false);break;
+    /* STY abs */
+        case (0x8C<<3)|0: _SA(c->PC++);break;
+        case (0x8C<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x8C<<3)|2: _SA((_GD()<<8)|c->AD);_SD(c->Y);_WR();break;
+        case (0x8C<<3)|3: _FETCH();break;
+        case (0x8C<<3)|4: assert(false);break;
+        case (0x8C<<3)|5: assert(false);break;
+        case (0x8C<<3)|6: assert(false);break;
+        case (0x8C<<3)|7: assert(false);break;
+    /* STA abs */
+        case (0x8D<<3)|0: _SA(c->PC++);break;
+        case (0x8D<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x8D<<3)|2: _SA((_GD()<<8)|c->AD);_SD(c->A);_WR();break;
+        case (0x8D<<3)|3: _FETCH();break;
+        case (0x8D<<3)|4: assert(false);break;
+        case (0x8D<<3)|5: assert(false);break;
+        case (0x8D<<3)|6: assert(false);break;
+        case (0x8D<<3)|7: assert(false);break;
+    /* STX abs */
+        case (0x8E<<3)|0: _SA(c->PC++);break;
+        case (0x8E<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x8E<<3)|2: _SA((_GD()<<8)|c->AD);_SD(c->X);_WR();break;
+        case (0x8E<<3)|3: _FETCH();break;
+        case (0x8E<<3)|4: assert(false);break;
+        case (0x8E<<3)|5: assert(false);break;
+        case (0x8E<<3)|6: assert(false);break;
+        case (0x8E<<3)|7: assert(false);break;
+    /* BBS0 zp,rel */
+        case (0x8F<<3)|0: _SA(c->PC++);break;
+        case (0x8F<<3)|1: _SA(_GD());break;
+        case (0x8F<<3)|2: c->AD=_GD();_SA(c->PC++);break;
+        case (0x8F<<3)|3: if(c->AD&(1<<0)){c->PC=c->PC+(int8_t)_GD();_FETCH();};_FETCH();break;
+        case (0x8F<<3)|4: assert(false);break;
+        case (0x8F<<3)|5: assert(false);break;
+        case (0x8F<<3)|6: assert(false);break;
+        case (0x8F<<3)|7: assert(false);break;
+    /* BCC # */
+        case (0x90<<3)|0: _SA(c->PC++);break;
+        case (0x90<<3)|1: _SA(c->PC);c->AD=c->PC+(int8_t)_GD();if((c->P&0x1)!=0x0){_FETCH();};break;
+        case (0x90<<3)|2: _SA((c->PC&0xFF00)|(c->AD&0x00FF));if((c->AD&0xFF00)==(c->PC&0xFF00)){c->PC=c->AD;c->irq_pip>>=1;c->nmi_pip>>=1;_FETCH();};break;
+        case (0x90<<3)|3: c->PC=c->AD;_FETCH();break;
+        case (0x90<<3)|4: assert(false);break;
+        case (0x90<<3)|5: assert(false);break;
+        case (0x90<<3)|6: assert(false);break;
+        case (0x90<<3)|7: assert(false);break;
+    /* STA (zp),Y */
+        case (0x91<<3)|0: _SA(c->PC++);break;
+        case (0x91<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0x91<<3)|2: _SA((c->AD+1)&0xFF);c->AD=_GD();break;
+        case (0x91<<3)|3: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->Y)&0xFF));break;
+        case (0x91<<3)|4: _SA(c->AD+c->Y);_SD(c->A);_WR();break;
+        case (0x91<<3)|5: _FETCH();break;
+        case (0x91<<3)|6: assert(false);break;
+        case (0x91<<3)|7: assert(false);break;
+    /* STA (zp) */
+        case (0x92<<3)|0: _SA(c->PC++);break;
+        case (0x92<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0x92<<3)|2: _SA((c->AD+1)&0xFF);c->AD=_GD();break;
+        case (0x92<<3)|3: _SA((_GD()<<8)|c->AD);_SD(c->A);_WR();break;
+        case (0x92<<3)|4: _FETCH();break;
+        case (0x92<<3)|5: assert(false);break;
+        case (0x92<<3)|6: assert(false);break;
+        case (0x92<<3)|7: assert(false);break;
+    /* NOP (zp),Y */
+        case (0x93<<3)|0: _SA(c->PC);break;
+        case (0x93<<3)|1: _FETCH();break;
+        case (0x93<<3)|2: assert(false);break;
+        case (0x93<<3)|3: assert(false);break;
+        case (0x93<<3)|4: assert(false);break;
+        case (0x93<<3)|5: assert(false);break;
+        case (0x93<<3)|6: assert(false);break;
+        case (0x93<<3)|7: assert(false);break;
+    /* STY zp,X */
+        case (0x94<<3)|0: _SA(c->PC++);break;
+        case (0x94<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0x94<<3)|2: _SA((c->AD+c->X)&0x00FF);_SD(c->Y);_WR();break;
+        case (0x94<<3)|3: _FETCH();break;
+        case (0x94<<3)|4: assert(false);break;
+        case (0x94<<3)|5: assert(false);break;
+        case (0x94<<3)|6: assert(false);break;
+        case (0x94<<3)|7: assert(false);break;
+    /* STA zp,X */
+        case (0x95<<3)|0: _SA(c->PC++);break;
+        case (0x95<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0x95<<3)|2: _SA((c->AD+c->X)&0x00FF);_SD(c->A);_WR();break;
+        case (0x95<<3)|3: _FETCH();break;
+        case (0x95<<3)|4: assert(false);break;
+        case (0x95<<3)|5: assert(false);break;
+        case (0x95<<3)|6: assert(false);break;
+        case (0x95<<3)|7: assert(false);break;
+    /* STX zp,Y */
+        case (0x96<<3)|0: _SA(c->PC++);break;
+        case (0x96<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0x96<<3)|2: _SA((c->AD+c->Y)&0x00FF);_SD(c->X);_WR();break;
+        case (0x96<<3)|3: _FETCH();break;
+        case (0x96<<3)|4: assert(false);break;
+        case (0x96<<3)|5: assert(false);break;
+        case (0x96<<3)|6: assert(false);break;
+        case (0x96<<3)|7: assert(false);break;
+    /* SMB1 zp */
+        case (0x97<<3)|0: _SA(c->PC++);break;
+        case (0x97<<3)|1: _SA(_GD());break;
+        case (0x97<<3)|2: _SD(_GD()|(1<<1));_WR();break;
+        case (0x97<<3)|3: _FETCH();break;
+        case (0x97<<3)|4: assert(false);break;
+        case (0x97<<3)|5: assert(false);break;
+        case (0x97<<3)|6: assert(false);break;
+        case (0x97<<3)|7: assert(false);break;
+    /* TYA  */
+        case (0x98<<3)|0: _SA(c->PC);break;
+        case (0x98<<3)|1: c->A=c->Y;_NZ(c->A);_FETCH();break;
+        case (0x98<<3)|2: assert(false);break;
+        case (0x98<<3)|3: assert(false);break;
+        case (0x98<<3)|4: assert(false);break;
+        case (0x98<<3)|5: assert(false);break;
+        case (0x98<<3)|6: assert(false);break;
+        case (0x98<<3)|7: assert(false);break;
+    /* STA abs,Y */
+        case (0x99<<3)|0: _SA(c->PC++);break;
+        case (0x99<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x99<<3)|2: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->Y)&0xFF));break;
+        case (0x99<<3)|3: _SA(c->AD+c->Y);_SD(c->A);_WR();break;
+        case (0x99<<3)|4: _FETCH();break;
+        case (0x99<<3)|5: assert(false);break;
+        case (0x99<<3)|6: assert(false);break;
+        case (0x99<<3)|7: assert(false);break;
+    /* TXS  */
+        case (0x9A<<3)|0: _SA(c->PC);break;
+        case (0x9A<<3)|1: c->S=c->X;_FETCH();break;
+        case (0x9A<<3)|2: assert(false);break;
+        case (0x9A<<3)|3: assert(false);break;
+        case (0x9A<<3)|4: assert(false);break;
+        case (0x9A<<3)|5: assert(false);break;
+        case (0x9A<<3)|6: assert(false);break;
+        case (0x9A<<3)|7: assert(false);break;
+    /* NOP abs,Y */
+        case (0x9B<<3)|0: _SA(c->PC);break;
+        case (0x9B<<3)|1: _FETCH();break;
+        case (0x9B<<3)|2: assert(false);break;
+        case (0x9B<<3)|3: assert(false);break;
+        case (0x9B<<3)|4: assert(false);break;
+        case (0x9B<<3)|5: assert(false);break;
+        case (0x9B<<3)|6: assert(false);break;
+        case (0x9B<<3)|7: assert(false);break;
+    /* STZ abs */
+        case (0x9C<<3)|0: _SA(c->PC++);break;
+        case (0x9C<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x9C<<3)|2: _SA((_GD()<<8)|c->AD);_SD(0);_WR();break;
+        case (0x9C<<3)|3: _FETCH();break;
+        case (0x9C<<3)|4: assert(false);break;
+        case (0x9C<<3)|5: assert(false);break;
+        case (0x9C<<3)|6: assert(false);break;
+        case (0x9C<<3)|7: assert(false);break;
+    /* STA abs,X */
+        case (0x9D<<3)|0: _SA(c->PC++);break;
+        case (0x9D<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x9D<<3)|2: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->X)&0xFF));break;
+        case (0x9D<<3)|3: _SA(c->AD+c->X);_SD(c->A);_WR();break;
+        case (0x9D<<3)|4: _FETCH();break;
+        case (0x9D<<3)|5: assert(false);break;
+        case (0x9D<<3)|6: assert(false);break;
+        case (0x9D<<3)|7: assert(false);break;
+    /* STZ abs,X */
+        case (0x9E<<3)|0: _SA(c->PC++);break;
+        case (0x9E<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0x9E<<3)|2: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->X)&0xFF));break;
+        case (0x9E<<3)|3: _SA(c->AD+c->X);_SD(0);_WR();break;
+        case (0x9E<<3)|4: _FETCH();break;
+        case (0x9E<<3)|5: assert(false);break;
+        case (0x9E<<3)|6: assert(false);break;
+        case (0x9E<<3)|7: assert(false);break;
+    /* BBS1 zp,rel */
+        case (0x9F<<3)|0: _SA(c->PC++);break;
+        case (0x9F<<3)|1: _SA(_GD());break;
+        case (0x9F<<3)|2: c->AD=_GD();_SA(c->PC++);break;
+        case (0x9F<<3)|3: if(c->AD&(1<<1)){c->PC=c->PC+(int8_t)_GD();_FETCH();};_FETCH();break;
+        case (0x9F<<3)|4: assert(false);break;
+        case (0x9F<<3)|5: assert(false);break;
+        case (0x9F<<3)|6: assert(false);break;
+        case (0x9F<<3)|7: assert(false);break;
+    /* LDY # */
+        case (0xA0<<3)|0: _SA(c->PC++);break;
+        case (0xA0<<3)|1: c->Y=_GD();_NZ(c->Y);_FETCH();break;
+        case (0xA0<<3)|2: assert(false);break;
+        case (0xA0<<3)|3: assert(false);break;
+        case (0xA0<<3)|4: assert(false);break;
+        case (0xA0<<3)|5: assert(false);break;
+        case (0xA0<<3)|6: assert(false);break;
+        case (0xA0<<3)|7: assert(false);break;
+    /* LDA (zp,X) */
+        case (0xA1<<3)|0: _SA(c->PC++);break;
+        case (0xA1<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0xA1<<3)|2: c->AD=(c->AD+c->X)&0xFF;_SA(c->AD);break;
+        case (0xA1<<3)|3: _SA((c->AD+1)&0xFF);c->AD=_GD();break;
+        case (0xA1<<3)|4: _SA((_GD()<<8)|c->AD);break;
+        case (0xA1<<3)|5: c->A=_GD();_NZ(c->A);_FETCH();break;
+        case (0xA1<<3)|6: assert(false);break;
+        case (0xA1<<3)|7: assert(false);break;
+    /* LDX # */
+        case (0xA2<<3)|0: _SA(c->PC++);break;
+        case (0xA2<<3)|1: c->X=_GD();_NZ(c->X);_FETCH();break;
+        case (0xA2<<3)|2: assert(false);break;
+        case (0xA2<<3)|3: assert(false);break;
+        case (0xA2<<3)|4: assert(false);break;
+        case (0xA2<<3)|5: assert(false);break;
+        case (0xA2<<3)|6: assert(false);break;
+        case (0xA2<<3)|7: assert(false);break;
+    /* NOP (zp,X) */
+        case (0xA3<<3)|0: _SA(c->PC);break;
+        case (0xA3<<3)|1: _FETCH();break;
+        case (0xA3<<3)|2: assert(false);break;
+        case (0xA3<<3)|3: assert(false);break;
+        case (0xA3<<3)|4: assert(false);break;
+        case (0xA3<<3)|5: assert(false);break;
+        case (0xA3<<3)|6: assert(false);break;
+        case (0xA3<<3)|7: assert(false);break;
+    /* LDY zp */
+        case (0xA4<<3)|0: _SA(c->PC++);break;
+        case (0xA4<<3)|1: _SA(_GD());break;
+        case (0xA4<<3)|2: c->Y=_GD();_NZ(c->Y);_FETCH();break;
+        case (0xA4<<3)|3: assert(false);break;
+        case (0xA4<<3)|4: assert(false);break;
+        case (0xA4<<3)|5: assert(false);break;
+        case (0xA4<<3)|6: assert(false);break;
+        case (0xA4<<3)|7: assert(false);break;
+    /* LDA zp */
+        case (0xA5<<3)|0: _SA(c->PC++);break;
+        case (0xA5<<3)|1: _SA(_GD());break;
+        case (0xA5<<3)|2: c->A=_GD();_NZ(c->A);_FETCH();break;
+        case (0xA5<<3)|3: assert(false);break;
+        case (0xA5<<3)|4: assert(false);break;
+        case (0xA5<<3)|5: assert(false);break;
+        case (0xA5<<3)|6: assert(false);break;
+        case (0xA5<<3)|7: assert(false);break;
+    /* LDX zp */
+        case (0xA6<<3)|0: _SA(c->PC++);break;
+        case (0xA6<<3)|1: _SA(_GD());break;
+        case (0xA6<<3)|2: c->X=_GD();_NZ(c->X);_FETCH();break;
+        case (0xA6<<3)|3: assert(false);break;
+        case (0xA6<<3)|4: assert(false);break;
+        case (0xA6<<3)|5: assert(false);break;
+        case (0xA6<<3)|6: assert(false);break;
+        case (0xA6<<3)|7: assert(false);break;
+    /* SMB2 zp */
+        case (0xA7<<3)|0: _SA(c->PC++);break;
+        case (0xA7<<3)|1: _SA(_GD());break;
+        case (0xA7<<3)|2: _SD(_GD()|(1<<2));_WR();break;
+        case (0xA7<<3)|3: _FETCH();break;
+        case (0xA7<<3)|4: assert(false);break;
+        case (0xA7<<3)|5: assert(false);break;
+        case (0xA7<<3)|6: assert(false);break;
+        case (0xA7<<3)|7: assert(false);break;
+    /* TAY  */
+        case (0xA8<<3)|0: _SA(c->PC);break;
+        case (0xA8<<3)|1: c->Y=c->A;_NZ(c->Y);_FETCH();break;
+        case (0xA8<<3)|2: assert(false);break;
+        case (0xA8<<3)|3: assert(false);break;
+        case (0xA8<<3)|4: assert(false);break;
+        case (0xA8<<3)|5: assert(false);break;
+        case (0xA8<<3)|6: assert(false);break;
+        case (0xA8<<3)|7: assert(false);break;
+    /* LDA # */
+        case (0xA9<<3)|0: _SA(c->PC++);break;
+        case (0xA9<<3)|1: c->A=_GD();_NZ(c->A);_FETCH();break;
+        case (0xA9<<3)|2: assert(false);break;
+        case (0xA9<<3)|3: assert(false);break;
+        case (0xA9<<3)|4: assert(false);break;
+        case (0xA9<<3)|5: assert(false);break;
+        case (0xA9<<3)|6: assert(false);break;
+        case (0xA9<<3)|7: assert(false);break;
+    /* TAX  */
+        case (0xAA<<3)|0: _SA(c->PC);break;
+        case (0xAA<<3)|1: c->X=c->A;_NZ(c->X);_FETCH();break;
+        case (0xAA<<3)|2: assert(false);break;
+        case (0xAA<<3)|3: assert(false);break;
+        case (0xAA<<3)|4: assert(false);break;
+        case (0xAA<<3)|5: assert(false);break;
+        case (0xAA<<3)|6: assert(false);break;
+        case (0xAA<<3)|7: assert(false);break;
+    /* NOP # */
+        case (0xAB<<3)|0: _SA(c->PC);break;
+        case (0xAB<<3)|1: _FETCH();break;
+        case (0xAB<<3)|2: assert(false);break;
+        case (0xAB<<3)|3: assert(false);break;
+        case (0xAB<<3)|4: assert(false);break;
+        case (0xAB<<3)|5: assert(false);break;
+        case (0xAB<<3)|6: assert(false);break;
+        case (0xAB<<3)|7: assert(false);break;
+    /* LDY abs */
+        case (0xAC<<3)|0: _SA(c->PC++);break;
+        case (0xAC<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0xAC<<3)|2: _SA((_GD()<<8)|c->AD);break;
+        case (0xAC<<3)|3: c->Y=_GD();_NZ(c->Y);_FETCH();break;
+        case (0xAC<<3)|4: assert(false);break;
+        case (0xAC<<3)|5: assert(false);break;
+        case (0xAC<<3)|6: assert(false);break;
+        case (0xAC<<3)|7: assert(false);break;
+    /* LDA abs */
+        case (0xAD<<3)|0: _SA(c->PC++);break;
+        case (0xAD<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0xAD<<3)|2: _SA((_GD()<<8)|c->AD);break;
+        case (0xAD<<3)|3: c->A=_GD();_NZ(c->A);_FETCH();break;
+        case (0xAD<<3)|4: assert(false);break;
+        case (0xAD<<3)|5: assert(false);break;
+        case (0xAD<<3)|6: assert(false);break;
+        case (0xAD<<3)|7: assert(false);break;
+    /* LDX abs */
+        case (0xAE<<3)|0: _SA(c->PC++);break;
+        case (0xAE<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0xAE<<3)|2: _SA((_GD()<<8)|c->AD);break;
+        case (0xAE<<3)|3: c->X=_GD();_NZ(c->X);_FETCH();break;
+        case (0xAE<<3)|4: assert(false);break;
+        case (0xAE<<3)|5: assert(false);break;
+        case (0xAE<<3)|6: assert(false);break;
+        case (0xAE<<3)|7: assert(false);break;
+    /* BBS2 zp,rel */
+        case (0xAF<<3)|0: _SA(c->PC++);break;
+        case (0xAF<<3)|1: _SA(_GD());break;
+        case (0xAF<<3)|2: c->AD=_GD();_SA(c->PC++);break;
+        case (0xAF<<3)|3: if(c->AD&(1<<2)){c->PC=c->PC+(int8_t)_GD();_FETCH();};_FETCH();break;
+        case (0xAF<<3)|4: assert(false);break;
+        case (0xAF<<3)|5: assert(false);break;
+        case (0xAF<<3)|6: assert(false);break;
+        case (0xAF<<3)|7: assert(false);break;
+    /* BCS # */
+        case (0xB0<<3)|0: _SA(c->PC++);break;
+        case (0xB0<<3)|1: _SA(c->PC);c->AD=c->PC+(int8_t)_GD();if((c->P&0x1)!=0x1){_FETCH();};break;
+        case (0xB0<<3)|2: _SA((c->PC&0xFF00)|(c->AD&0x00FF));if((c->AD&0xFF00)==(c->PC&0xFF00)){c->PC=c->AD;c->irq_pip>>=1;c->nmi_pip>>=1;_FETCH();};break;
+        case (0xB0<<3)|3: c->PC=c->AD;_FETCH();break;
+        case (0xB0<<3)|4: assert(false);break;
+        case (0xB0<<3)|5: assert(false);break;
+        case (0xB0<<3)|6: assert(false);break;
+        case (0xB0<<3)|7: assert(false);break;
+    /* LDA (zp),Y */
+        case (0xB1<<3)|0: _SA(c->PC++);break;
+        case (0xB1<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0xB1<<3)|2: _SA((c->AD+1)&0xFF);c->AD=_GD();break;
+        case (0xB1<<3)|3: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->Y)&0xFF));c->IR+=(~((c->AD>>8)-((c->AD+c->Y)>>8)))&1;break;
+        case (0xB1<<3)|4: _SA(c->AD+c->Y);break;
+        case (0xB1<<3)|5: c->A=_GD();_NZ(c->A);_FETCH();break;
+        case (0xB1<<3)|6: assert(false);break;
+        case (0xB1<<3)|7: assert(false);break;
+    /* LDA (zp) */
+        case (0xB2<<3)|0: _SA(c->PC++);break;
+        case (0xB2<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0xB2<<3)|2: _SA((c->AD+1)&0xFF);c->AD=_GD();break;
+        case (0xB2<<3)|3: _SA((_GD()<<8)|c->AD);break;
+        case (0xB2<<3)|4: c->A=_GD();_NZ(c->A);_FETCH();break;
+        case (0xB2<<3)|5: assert(false);break;
+        case (0xB2<<3)|6: assert(false);break;
+        case (0xB2<<3)|7: assert(false);break;
+    /* NOP (zp),Y */
+        case (0xB3<<3)|0: _SA(c->PC);break;
+        case (0xB3<<3)|1: _FETCH();break;
+        case (0xB3<<3)|2: assert(false);break;
+        case (0xB3<<3)|3: assert(false);break;
+        case (0xB3<<3)|4: assert(false);break;
+        case (0xB3<<3)|5: assert(false);break;
+        case (0xB3<<3)|6: assert(false);break;
+        case (0xB3<<3)|7: assert(false);break;
+    /* LDY zp,X */
+        case (0xB4<<3)|0: _SA(c->PC++);break;
+        case (0xB4<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0xB4<<3)|2: _SA((c->AD+c->X)&0x00FF);break;
+        case (0xB4<<3)|3: c->Y=_GD();_NZ(c->Y);_FETCH();break;
+        case (0xB4<<3)|4: assert(false);break;
+        case (0xB4<<3)|5: assert(false);break;
+        case (0xB4<<3)|6: assert(false);break;
+        case (0xB4<<3)|7: assert(false);break;
+    /* LDA zp,X */
+        case (0xB5<<3)|0: _SA(c->PC++);break;
+        case (0xB5<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0xB5<<3)|2: _SA((c->AD+c->X)&0x00FF);break;
+        case (0xB5<<3)|3: c->A=_GD();_NZ(c->A);_FETCH();break;
+        case (0xB5<<3)|4: assert(false);break;
+        case (0xB5<<3)|5: assert(false);break;
+        case (0xB5<<3)|6: assert(false);break;
+        case (0xB5<<3)|7: assert(false);break;
+    /* LDX zp,Y */
+        case (0xB6<<3)|0: _SA(c->PC++);break;
+        case (0xB6<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0xB6<<3)|2: _SA((c->AD+c->Y)&0x00FF);break;
+        case (0xB6<<3)|3: c->X=_GD();_NZ(c->X);_FETCH();break;
+        case (0xB6<<3)|4: assert(false);break;
+        case (0xB6<<3)|5: assert(false);break;
+        case (0xB6<<3)|6: assert(false);break;
+        case (0xB6<<3)|7: assert(false);break;
+    /* SMB3 zp */
+        case (0xB7<<3)|0: _SA(c->PC++);break;
+        case (0xB7<<3)|1: _SA(_GD());break;
+        case (0xB7<<3)|2: _SD(_GD()|(1<<3));_WR();break;
+        case (0xB7<<3)|3: _FETCH();break;
+        case (0xB7<<3)|4: assert(false);break;
+        case (0xB7<<3)|5: assert(false);break;
+        case (0xB7<<3)|6: assert(false);break;
+        case (0xB7<<3)|7: assert(false);break;
+    /* CLV  */
+        case (0xB8<<3)|0: _SA(c->PC);break;
+        case (0xB8<<3)|1: c->P&=~0x40;_FETCH();break;
+        case (0xB8<<3)|2: assert(false);break;
+        case (0xB8<<3)|3: assert(false);break;
+        case (0xB8<<3)|4: assert(false);break;
+        case (0xB8<<3)|5: assert(false);break;
+        case (0xB8<<3)|6: assert(false);break;
+        case (0xB8<<3)|7: assert(false);break;
+    /* LDA abs,Y */
+        case (0xB9<<3)|0: _SA(c->PC++);break;
+        case (0xB9<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0xB9<<3)|2: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->Y)&0xFF));c->IR+=(~((c->AD>>8)-((c->AD+c->Y)>>8)))&1;break;
+        case (0xB9<<3)|3: _SA(c->AD+c->Y);break;
+        case (0xB9<<3)|4: c->A=_GD();_NZ(c->A);_FETCH();break;
+        case (0xB9<<3)|5: assert(false);break;
+        case (0xB9<<3)|6: assert(false);break;
+        case (0xB9<<3)|7: assert(false);break;
+    /* TSX  */
+        case (0xBA<<3)|0: _SA(c->PC);break;
+        case (0xBA<<3)|1: c->X=c->S;_NZ(c->X);_FETCH();break;
+        case (0xBA<<3)|2: assert(false);break;
+        case (0xBA<<3)|3: assert(false);break;
+        case (0xBA<<3)|4: assert(false);break;
+        case (0xBA<<3)|5: assert(false);break;
+        case (0xBA<<3)|6: assert(false);break;
+        case (0xBA<<3)|7: assert(false);break;
+    /* NOP abs,Y */
+        case (0xBB<<3)|0: _SA(c->PC);break;
+        case (0xBB<<3)|1: _FETCH();break;
+        case (0xBB<<3)|2: assert(false);break;
+        case (0xBB<<3)|3: assert(false);break;
+        case (0xBB<<3)|4: assert(false);break;
+        case (0xBB<<3)|5: assert(false);break;
+        case (0xBB<<3)|6: assert(false);break;
+        case (0xBB<<3)|7: assert(false);break;
+    /* LDY abs,X */
+        case (0xBC<<3)|0: _SA(c->PC++);break;
+        case (0xBC<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0xBC<<3)|2: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->X)&0xFF));c->IR+=(~((c->AD>>8)-((c->AD+c->X)>>8)))&1;break;
+        case (0xBC<<3)|3: _SA(c->AD+c->X);break;
+        case (0xBC<<3)|4: c->Y=_GD();_NZ(c->Y);_FETCH();break;
+        case (0xBC<<3)|5: assert(false);break;
+        case (0xBC<<3)|6: assert(false);break;
+        case (0xBC<<3)|7: assert(false);break;
+    /* LDA abs,X */
+        case (0xBD<<3)|0: _SA(c->PC++);break;
+        case (0xBD<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0xBD<<3)|2: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->X)&0xFF));c->IR+=(~((c->AD>>8)-((c->AD+c->X)>>8)))&1;break;
+        case (0xBD<<3)|3: _SA(c->AD+c->X);break;
+        case (0xBD<<3)|4: c->A=_GD();_NZ(c->A);_FETCH();break;
+        case (0xBD<<3)|5: assert(false);break;
+        case (0xBD<<3)|6: assert(false);break;
+        case (0xBD<<3)|7: assert(false);break;
+    /* LDX abs,Y */
+        case (0xBE<<3)|0: _SA(c->PC++);break;
+        case (0xBE<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0xBE<<3)|2: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->Y)&0xFF));c->IR+=(~((c->AD>>8)-((c->AD+c->Y)>>8)))&1;break;
+        case (0xBE<<3)|3: _SA(c->AD+c->Y);break;
+        case (0xBE<<3)|4: c->X=_GD();_NZ(c->X);_FETCH();break;
+        case (0xBE<<3)|5: assert(false);break;
+        case (0xBE<<3)|6: assert(false);break;
+        case (0xBE<<3)|7: assert(false);break;
+    /* BBS3 zp,rel */
+        case (0xBF<<3)|0: _SA(c->PC++);break;
+        case (0xBF<<3)|1: _SA(_GD());break;
+        case (0xBF<<3)|2: c->AD=_GD();_SA(c->PC++);break;
+        case (0xBF<<3)|3: if(c->AD&(1<<3)){c->PC=c->PC+(int8_t)_GD();_FETCH();};_FETCH();break;
+        case (0xBF<<3)|4: assert(false);break;
+        case (0xBF<<3)|5: assert(false);break;
+        case (0xBF<<3)|6: assert(false);break;
+        case (0xBF<<3)|7: assert(false);break;
+    /* CPY # */
+        case (0xC0<<3)|0: _SA(c->PC++);break;
+        case (0xC0<<3)|1: _m65c02_cmp(c, c->Y, _GD());_FETCH();break;
+        case (0xC0<<3)|2: assert(false);break;
+        case (0xC0<<3)|3: assert(false);break;
+        case (0xC0<<3)|4: assert(false);break;
+        case (0xC0<<3)|5: assert(false);break;
+        case (0xC0<<3)|6: assert(false);break;
+        case (0xC0<<3)|7: assert(false);break;
+    /* CMP (zp,X) */
+        case (0xC1<<3)|0: _SA(c->PC++);break;
+        case (0xC1<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0xC1<<3)|2: c->AD=(c->AD+c->X)&0xFF;_SA(c->AD);break;
+        case (0xC1<<3)|3: _SA((c->AD+1)&0xFF);c->AD=_GD();break;
+        case (0xC1<<3)|4: _SA((_GD()<<8)|c->AD);break;
+        case (0xC1<<3)|5: _m65c02_cmp(c, c->A, _GD());_FETCH();break;
+        case (0xC1<<3)|6: assert(false);break;
+        case (0xC1<<3)|7: assert(false);break;
+    /* LDD # */
+        case (0xC2<<3)|0: _SA(c->PC++);break;
+        case (0xC2<<3)|1: _FETCH();break;
+        case (0xC2<<3)|2: assert(false);break;
+        case (0xC2<<3)|3: assert(false);break;
+        case (0xC2<<3)|4: assert(false);break;
+        case (0xC2<<3)|5: assert(false);break;
+        case (0xC2<<3)|6: assert(false);break;
+        case (0xC2<<3)|7: assert(false);break;
+    /* NOP (zp,X) */
+        case (0xC3<<3)|0: _SA(c->PC);break;
+        case (0xC3<<3)|1: _FETCH();break;
+        case (0xC3<<3)|2: assert(false);break;
+        case (0xC3<<3)|3: assert(false);break;
+        case (0xC3<<3)|4: assert(false);break;
+        case (0xC3<<3)|5: assert(false);break;
+        case (0xC3<<3)|6: assert(false);break;
+        case (0xC3<<3)|7: assert(false);break;
+    /* CPY zp */
+        case (0xC4<<3)|0: _SA(c->PC++);break;
+        case (0xC4<<3)|1: _SA(_GD());break;
+        case (0xC4<<3)|2: _m65c02_cmp(c, c->Y, _GD());_FETCH();break;
+        case (0xC4<<3)|3: assert(false);break;
+        case (0xC4<<3)|4: assert(false);break;
+        case (0xC4<<3)|5: assert(false);break;
+        case (0xC4<<3)|6: assert(false);break;
+        case (0xC4<<3)|7: assert(false);break;
+    /* CMP zp */
+        case (0xC5<<3)|0: _SA(c->PC++);break;
+        case (0xC5<<3)|1: _SA(_GD());break;
+        case (0xC5<<3)|2: _m65c02_cmp(c, c->A, _GD());_FETCH();break;
+        case (0xC5<<3)|3: assert(false);break;
+        case (0xC5<<3)|4: assert(false);break;
+        case (0xC5<<3)|5: assert(false);break;
+        case (0xC5<<3)|6: assert(false);break;
+        case (0xC5<<3)|7: assert(false);break;
+    /* DEC zp */
+        case (0xC6<<3)|0: _SA(c->PC++);break;
+        case (0xC6<<3)|1: _SA(_GD());break;
+        case (0xC6<<3)|2: c->AD=_GD();break;
+        case (0xC6<<3)|3: c->AD--;_NZ(c->AD);_SD(c->AD);_WR();break;
+        case (0xC6<<3)|4: _FETCH();break;
+        case (0xC6<<3)|5: assert(false);break;
+        case (0xC6<<3)|6: assert(false);break;
+        case (0xC6<<3)|7: assert(false);break;
+    /* SMB4 zp */
+        case (0xC7<<3)|0: _SA(c->PC++);break;
+        case (0xC7<<3)|1: _SA(_GD());break;
+        case (0xC7<<3)|2: _SD(_GD()|(1<<4));_WR();break;
+        case (0xC7<<3)|3: _FETCH();break;
+        case (0xC7<<3)|4: assert(false);break;
+        case (0xC7<<3)|5: assert(false);break;
+        case (0xC7<<3)|6: assert(false);break;
+        case (0xC7<<3)|7: assert(false);break;
+    /* INY  */
+        case (0xC8<<3)|0: _SA(c->PC);break;
+        case (0xC8<<3)|1: c->Y++;_NZ(c->Y);_FETCH();break;
+        case (0xC8<<3)|2: assert(false);break;
+        case (0xC8<<3)|3: assert(false);break;
+        case (0xC8<<3)|4: assert(false);break;
+        case (0xC8<<3)|5: assert(false);break;
+        case (0xC8<<3)|6: assert(false);break;
+        case (0xC8<<3)|7: assert(false);break;
+    /* CMP # */
+        case (0xC9<<3)|0: _SA(c->PC++);break;
+        case (0xC9<<3)|1: _m65c02_cmp(c, c->A, _GD());_FETCH();break;
+        case (0xC9<<3)|2: assert(false);break;
+        case (0xC9<<3)|3: assert(false);break;
+        case (0xC9<<3)|4: assert(false);break;
+        case (0xC9<<3)|5: assert(false);break;
+        case (0xC9<<3)|6: assert(false);break;
+        case (0xC9<<3)|7: assert(false);break;
+    /* DEX  */
+        case (0xCA<<3)|0: _SA(c->PC);break;
+        case (0xCA<<3)|1: c->X--;_NZ(c->X);_FETCH();break;
+        case (0xCA<<3)|2: assert(false);break;
+        case (0xCA<<3)|3: assert(false);break;
+        case (0xCA<<3)|4: assert(false);break;
+        case (0xCA<<3)|5: assert(false);break;
+        case (0xCA<<3)|6: assert(false);break;
+        case (0xCA<<3)|7: assert(false);break;
+    /* NOP # */
+        case (0xCB<<3)|0: _SA(c->PC);break;
+        case (0xCB<<3)|1: _FETCH();break;
+        case (0xCB<<3)|2: assert(false);break;
+        case (0xCB<<3)|3: assert(false);break;
+        case (0xCB<<3)|4: assert(false);break;
+        case (0xCB<<3)|5: assert(false);break;
+        case (0xCB<<3)|6: assert(false);break;
+        case (0xCB<<3)|7: assert(false);break;
+    /* CPY abs */
+        case (0xCC<<3)|0: _SA(c->PC++);break;
+        case (0xCC<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0xCC<<3)|2: _SA((_GD()<<8)|c->AD);break;
+        case (0xCC<<3)|3: _m65c02_cmp(c, c->Y, _GD());_FETCH();break;
+        case (0xCC<<3)|4: assert(false);break;
+        case (0xCC<<3)|5: assert(false);break;
+        case (0xCC<<3)|6: assert(false);break;
+        case (0xCC<<3)|7: assert(false);break;
+    /* CMP abs */
+        case (0xCD<<3)|0: _SA(c->PC++);break;
+        case (0xCD<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0xCD<<3)|2: _SA((_GD()<<8)|c->AD);break;
+        case (0xCD<<3)|3: _m65c02_cmp(c, c->A, _GD());_FETCH();break;
+        case (0xCD<<3)|4: assert(false);break;
+        case (0xCD<<3)|5: assert(false);break;
+        case (0xCD<<3)|6: assert(false);break;
+        case (0xCD<<3)|7: assert(false);break;
+    /* DEC abs */
+        case (0xCE<<3)|0: _SA(c->PC++);break;
+        case (0xCE<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0xCE<<3)|2: _SA((_GD()<<8)|c->AD);break;
+        case (0xCE<<3)|3: c->AD=_GD();break;
+        case (0xCE<<3)|4: c->AD--;_NZ(c->AD);_SD(c->AD);_WR();break;
+        case (0xCE<<3)|5: _FETCH();break;
+        case (0xCE<<3)|6: assert(false);break;
+        case (0xCE<<3)|7: assert(false);break;
+    /* BBS4 zp,rel */
+        case (0xCF<<3)|0: _SA(c->PC++);break;
+        case (0xCF<<3)|1: _SA(_GD());break;
+        case (0xCF<<3)|2: c->AD=_GD();_SA(c->PC++);break;
+        case (0xCF<<3)|3: if(c->AD&(1<<4)){c->PC=c->PC+(int8_t)_GD();_FETCH();};_FETCH();break;
+        case (0xCF<<3)|4: assert(false);break;
+        case (0xCF<<3)|5: assert(false);break;
+        case (0xCF<<3)|6: assert(false);break;
+        case (0xCF<<3)|7: assert(false);break;
+    /* BNE # */
+        case (0xD0<<3)|0: _SA(c->PC++);break;
+        case (0xD0<<3)|1: _SA(c->PC);c->AD=c->PC+(int8_t)_GD();if((c->P&0x2)!=0x0){_FETCH();};break;
+        case (0xD0<<3)|2: _SA((c->PC&0xFF00)|(c->AD&0x00FF));if((c->AD&0xFF00)==(c->PC&0xFF00)){c->PC=c->AD;c->irq_pip>>=1;c->nmi_pip>>=1;_FETCH();};break;
+        case (0xD0<<3)|3: c->PC=c->AD;_FETCH();break;
+        case (0xD0<<3)|4: assert(false);break;
+        case (0xD0<<3)|5: assert(false);break;
+        case (0xD0<<3)|6: assert(false);break;
+        case (0xD0<<3)|7: assert(false);break;
+    /* CMP (zp),Y */
+        case (0xD1<<3)|0: _SA(c->PC++);break;
+        case (0xD1<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0xD1<<3)|2: _SA((c->AD+1)&0xFF);c->AD=_GD();break;
+        case (0xD1<<3)|3: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->Y)&0xFF));c->IR+=(~((c->AD>>8)-((c->AD+c->Y)>>8)))&1;break;
+        case (0xD1<<3)|4: _SA(c->AD+c->Y);break;
+        case (0xD1<<3)|5: _m65c02_cmp(c, c->A, _GD());_FETCH();break;
+        case (0xD1<<3)|6: assert(false);break;
+        case (0xD1<<3)|7: assert(false);break;
+    /* CMP (zp) */
+        case (0xD2<<3)|0: _SA(c->PC++);break;
+        case (0xD2<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0xD2<<3)|2: _SA((c->AD+1)&0xFF);c->AD=_GD();break;
+        case (0xD2<<3)|3: _SA((_GD()<<8)|c->AD);break;
+        case (0xD2<<3)|4: _m65c02_cmp(c, c->A, _GD());_FETCH();break;
+        case (0xD2<<3)|5: assert(false);break;
+        case (0xD2<<3)|6: assert(false);break;
+        case (0xD2<<3)|7: assert(false);break;
+    /* NOP (zp),Y */
+        case (0xD3<<3)|0: _SA(c->PC);break;
+        case (0xD3<<3)|1: _FETCH();break;
+        case (0xD3<<3)|2: assert(false);break;
+        case (0xD3<<3)|3: assert(false);break;
+        case (0xD3<<3)|4: assert(false);break;
+        case (0xD3<<3)|5: assert(false);break;
+        case (0xD3<<3)|6: assert(false);break;
+        case (0xD3<<3)|7: assert(false);break;
+    /* LDD zp,X */
+        case (0xD4<<3)|0: _SA(c->PC++);break;
+        case (0xD4<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0xD4<<3)|2: _SA((c->AD+c->X)&0x00FF);break;
+        case (0xD4<<3)|3: _FETCH();break;
+        case (0xD4<<3)|4: assert(false);break;
+        case (0xD4<<3)|5: assert(false);break;
+        case (0xD4<<3)|6: assert(false);break;
+        case (0xD4<<3)|7: assert(false);break;
+    /* CMP zp,X */
+        case (0xD5<<3)|0: _SA(c->PC++);break;
+        case (0xD5<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0xD5<<3)|2: _SA((c->AD+c->X)&0x00FF);break;
+        case (0xD5<<3)|3: _m65c02_cmp(c, c->A, _GD());_FETCH();break;
+        case (0xD5<<3)|4: assert(false);break;
+        case (0xD5<<3)|5: assert(false);break;
+        case (0xD5<<3)|6: assert(false);break;
+        case (0xD5<<3)|7: assert(false);break;
+    /* DEC zp,X */
+        case (0xD6<<3)|0: _SA(c->PC++);break;
+        case (0xD6<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0xD6<<3)|2: _SA((c->AD+c->X)&0x00FF);break;
+        case (0xD6<<3)|3: c->AD=_GD();break;
+        case (0xD6<<3)|4: c->AD--;_NZ(c->AD);_SD(c->AD);_WR();break;
+        case (0xD6<<3)|5: _FETCH();break;
+        case (0xD6<<3)|6: assert(false);break;
+        case (0xD6<<3)|7: assert(false);break;
+    /* SMB5 zp */
+        case (0xD7<<3)|0: _SA(c->PC++);break;
+        case (0xD7<<3)|1: _SA(_GD());break;
+        case (0xD7<<3)|2: _SD(_GD()|(1<<5));_WR();break;
+        case (0xD7<<3)|3: _FETCH();break;
+        case (0xD7<<3)|4: assert(false);break;
+        case (0xD7<<3)|5: assert(false);break;
+        case (0xD7<<3)|6: assert(false);break;
+        case (0xD7<<3)|7: assert(false);break;
+    /* CLD  */
+        case (0xD8<<3)|0: _SA(c->PC);break;
+        case (0xD8<<3)|1: c->P&=~0x8;_FETCH();break;
+        case (0xD8<<3)|2: assert(false);break;
+        case (0xD8<<3)|3: assert(false);break;
+        case (0xD8<<3)|4: assert(false);break;
+        case (0xD8<<3)|5: assert(false);break;
+        case (0xD8<<3)|6: assert(false);break;
+        case (0xD8<<3)|7: assert(false);break;
+    /* CMP abs,Y */
+        case (0xD9<<3)|0: _SA(c->PC++);break;
+        case (0xD9<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0xD9<<3)|2: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->Y)&0xFF));c->IR+=(~((c->AD>>8)-((c->AD+c->Y)>>8)))&1;break;
+        case (0xD9<<3)|3: _SA(c->AD+c->Y);break;
+        case (0xD9<<3)|4: _m65c02_cmp(c, c->A, _GD());_FETCH();break;
+        case (0xD9<<3)|5: assert(false);break;
+        case (0xD9<<3)|6: assert(false);break;
+        case (0xD9<<3)|7: assert(false);break;
+    /* PHX  */
+        case (0xDA<<3)|0: _SA(c->PC);break;
+        case (0xDA<<3)|1: _SAD(0x0100|c->S--,c->X);_WR();break;
+        case (0xDA<<3)|2: _FETCH();break;
+        case (0xDA<<3)|3: assert(false);break;
+        case (0xDA<<3)|4: assert(false);break;
+        case (0xDA<<3)|5: assert(false);break;
+        case (0xDA<<3)|6: assert(false);break;
+        case (0xDA<<3)|7: assert(false);break;
+    /* NOP abs,Y */
+        case (0xDB<<3)|0: _SA(c->PC);break;
+        case (0xDB<<3)|1: _FETCH();break;
+        case (0xDB<<3)|2: assert(false);break;
+        case (0xDB<<3)|3: assert(false);break;
+        case (0xDB<<3)|4: assert(false);break;
+        case (0xDB<<3)|5: assert(false);break;
+        case (0xDB<<3)|6: assert(false);break;
+        case (0xDB<<3)|7: assert(false);break;
+    /* LDD abs */
+        case (0xDC<<3)|0: _SA(c->PC++);break;
+        case (0xDC<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0xDC<<3)|2: _SA((_GD()<<8)|c->AD);break;
+        case (0xDC<<3)|3: _FETCH();break;
+        case (0xDC<<3)|4: assert(false);break;
+        case (0xDC<<3)|5: assert(false);break;
+        case (0xDC<<3)|6: assert(false);break;
+        case (0xDC<<3)|7: assert(false);break;
+    /* CMP abs,X */
+        case (0xDD<<3)|0: _SA(c->PC++);break;
+        case (0xDD<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0xDD<<3)|2: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->X)&0xFF));c->IR+=(~((c->AD>>8)-((c->AD+c->X)>>8)))&1;break;
+        case (0xDD<<3)|3: _SA(c->AD+c->X);break;
+        case (0xDD<<3)|4: _m65c02_cmp(c, c->A, _GD());_FETCH();break;
+        case (0xDD<<3)|5: assert(false);break;
+        case (0xDD<<3)|6: assert(false);break;
+        case (0xDD<<3)|7: assert(false);break;
+    /* DEC abs,X */
+        case (0xDE<<3)|0: _SA(c->PC++);break;
+        case (0xDE<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0xDE<<3)|2: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->X)&0xFF));break;
+        case (0xDE<<3)|3: _SA(c->AD+c->X);break;
+        case (0xDE<<3)|4: c->AD=_GD();break;
+        case (0xDE<<3)|5: c->AD--;_NZ(c->AD);_SD(c->AD);_WR();break;
+        case (0xDE<<3)|6: _FETCH();break;
+        case (0xDE<<3)|7: assert(false);break;
+    /* BBS5 zp,rel */
+        case (0xDF<<3)|0: _SA(c->PC++);break;
+        case (0xDF<<3)|1: _SA(_GD());break;
+        case (0xDF<<3)|2: c->AD=_GD();_SA(c->PC++);break;
+        case (0xDF<<3)|3: if(c->AD&(1<<5)){c->PC=c->PC+(int8_t)_GD();_FETCH();};_FETCH();break;
+        case (0xDF<<3)|4: assert(false);break;
+        case (0xDF<<3)|5: assert(false);break;
+        case (0xDF<<3)|6: assert(false);break;
+        case (0xDF<<3)|7: assert(false);break;
+    /* CPX # */
+        case (0xE0<<3)|0: _SA(c->PC++);break;
+        case (0xE0<<3)|1: _m65c02_cmp(c, c->X, _GD());_FETCH();break;
+        case (0xE0<<3)|2: assert(false);break;
+        case (0xE0<<3)|3: assert(false);break;
+        case (0xE0<<3)|4: assert(false);break;
+        case (0xE0<<3)|5: assert(false);break;
+        case (0xE0<<3)|6: assert(false);break;
+        case (0xE0<<3)|7: assert(false);break;
+    /* SBC (zp,X) */
+        case (0xE1<<3)|0: _SA(c->PC++);break;
+        case (0xE1<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0xE1<<3)|2: c->AD=(c->AD+c->X)&0xFF;_SA(c->AD);break;
+        case (0xE1<<3)|3: _SA((c->AD+1)&0xFF);c->AD=_GD();break;
+        case (0xE1<<3)|4: _SA((_GD()<<8)|c->AD);break;
+        case (0xE1<<3)|5: _m65c02_sbc(c,_GD());if(c->P&M65C02_DF){c->P=((c->P&~(M65C02_NF|M65C02_ZF))|((c->A&0xFF)?(c->A&M65C02_NF):M65C02_ZF));};_FETCH();break;
+        case (0xE1<<3)|6: assert(false);break;
+        case (0xE1<<3)|7: assert(false);break;
+    /* LDD # */
+        case (0xE2<<3)|0: _SA(c->PC++);break;
+        case (0xE2<<3)|1: _FETCH();break;
+        case (0xE2<<3)|2: assert(false);break;
+        case (0xE2<<3)|3: assert(false);break;
+        case (0xE2<<3)|4: assert(false);break;
+        case (0xE2<<3)|5: assert(false);break;
+        case (0xE2<<3)|6: assert(false);break;
+        case (0xE2<<3)|7: assert(false);break;
+    /* NOP (zp,X) */
+        case (0xE3<<3)|0: _SA(c->PC);break;
+        case (0xE3<<3)|1: _FETCH();break;
+        case (0xE3<<3)|2: assert(false);break;
+        case (0xE3<<3)|3: assert(false);break;
+        case (0xE3<<3)|4: assert(false);break;
+        case (0xE3<<3)|5: assert(false);break;
+        case (0xE3<<3)|6: assert(false);break;
+        case (0xE3<<3)|7: assert(false);break;
+    /* CPX zp */
+        case (0xE4<<3)|0: _SA(c->PC++);break;
+        case (0xE4<<3)|1: _SA(_GD());break;
+        case (0xE4<<3)|2: _m65c02_cmp(c, c->X, _GD());_FETCH();break;
+        case (0xE4<<3)|3: assert(false);break;
+        case (0xE4<<3)|4: assert(false);break;
+        case (0xE4<<3)|5: assert(false);break;
+        case (0xE4<<3)|6: assert(false);break;
+        case (0xE4<<3)|7: assert(false);break;
+    /* SBC zp */
+        case (0xE5<<3)|0: _SA(c->PC++);break;
+        case (0xE5<<3)|1: _SA(_GD());break;
+        case (0xE5<<3)|2: _m65c02_sbc(c,_GD());if(c->P&M65C02_DF){c->P=((c->P&~(M65C02_NF|M65C02_ZF))|((c->A&0xFF)?(c->A&M65C02_NF):M65C02_ZF));};_FETCH();break;
+        case (0xE5<<3)|3: assert(false);break;
+        case (0xE5<<3)|4: assert(false);break;
+        case (0xE5<<3)|5: assert(false);break;
+        case (0xE5<<3)|6: assert(false);break;
+        case (0xE5<<3)|7: assert(false);break;
+    /* INC zp */
+        case (0xE6<<3)|0: _SA(c->PC++);break;
+        case (0xE6<<3)|1: _SA(_GD());break;
+        case (0xE6<<3)|2: c->AD=_GD();break;
+        case (0xE6<<3)|3: c->AD++;_NZ(c->AD);_SD(c->AD);_WR();break;
+        case (0xE6<<3)|4: _FETCH();break;
+        case (0xE6<<3)|5: assert(false);break;
+        case (0xE6<<3)|6: assert(false);break;
+        case (0xE6<<3)|7: assert(false);break;
+    /* SMB6 zp */
+        case (0xE7<<3)|0: _SA(c->PC++);break;
+        case (0xE7<<3)|1: _SA(_GD());break;
+        case (0xE7<<3)|2: _SD(_GD()|(1<<6));_WR();break;
+        case (0xE7<<3)|3: _FETCH();break;
+        case (0xE7<<3)|4: assert(false);break;
+        case (0xE7<<3)|5: assert(false);break;
+        case (0xE7<<3)|6: assert(false);break;
+        case (0xE7<<3)|7: assert(false);break;
+    /* INX  */
+        case (0xE8<<3)|0: _SA(c->PC);break;
+        case (0xE8<<3)|1: c->X++;_NZ(c->X);_FETCH();break;
+        case (0xE8<<3)|2: assert(false);break;
+        case (0xE8<<3)|3: assert(false);break;
+        case (0xE8<<3)|4: assert(false);break;
+        case (0xE8<<3)|5: assert(false);break;
+        case (0xE8<<3)|6: assert(false);break;
+        case (0xE8<<3)|7: assert(false);break;
+    /* SBC # */
+        case (0xE9<<3)|0: _SA(c->PC++);break;
+        case (0xE9<<3)|1: _m65c02_sbc(c,_GD());if(c->P&M65C02_DF){c->P=((c->P&~(M65C02_NF|M65C02_ZF))|((c->A&0xFF)?(c->A&M65C02_NF):M65C02_ZF));};_FETCH();break;
+        case (0xE9<<3)|2: assert(false);break;
+        case (0xE9<<3)|3: assert(false);break;
+        case (0xE9<<3)|4: assert(false);break;
+        case (0xE9<<3)|5: assert(false);break;
+        case (0xE9<<3)|6: assert(false);break;
+        case (0xE9<<3)|7: assert(false);break;
+    /* NOP  */
+        case (0xEA<<3)|0: _SA(c->PC);break;
+        case (0xEA<<3)|1: _FETCH();break;
+        case (0xEA<<3)|2: assert(false);break;
+        case (0xEA<<3)|3: assert(false);break;
+        case (0xEA<<3)|4: assert(false);break;
+        case (0xEA<<3)|5: assert(false);break;
+        case (0xEA<<3)|6: assert(false);break;
+        case (0xEA<<3)|7: assert(false);break;
+    /* NOP # */
+        case (0xEB<<3)|0: _SA(c->PC);break;
+        case (0xEB<<3)|1: _FETCH();break;
+        case (0xEB<<3)|2: assert(false);break;
+        case (0xEB<<3)|3: assert(false);break;
+        case (0xEB<<3)|4: assert(false);break;
+        case (0xEB<<3)|5: assert(false);break;
+        case (0xEB<<3)|6: assert(false);break;
+        case (0xEB<<3)|7: assert(false);break;
+    /* CPX abs */
+        case (0xEC<<3)|0: _SA(c->PC++);break;
+        case (0xEC<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0xEC<<3)|2: _SA((_GD()<<8)|c->AD);break;
+        case (0xEC<<3)|3: _m65c02_cmp(c, c->X, _GD());_FETCH();break;
+        case (0xEC<<3)|4: assert(false);break;
+        case (0xEC<<3)|5: assert(false);break;
+        case (0xEC<<3)|6: assert(false);break;
+        case (0xEC<<3)|7: assert(false);break;
+    /* SBC abs */
+        case (0xED<<3)|0: _SA(c->PC++);break;
+        case (0xED<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0xED<<3)|2: _SA((_GD()<<8)|c->AD);break;
+        case (0xED<<3)|3: _m65c02_sbc(c,_GD());if(c->P&M65C02_DF){c->P=((c->P&~(M65C02_NF|M65C02_ZF))|((c->A&0xFF)?(c->A&M65C02_NF):M65C02_ZF));};_FETCH();break;
+        case (0xED<<3)|4: assert(false);break;
+        case (0xED<<3)|5: assert(false);break;
+        case (0xED<<3)|6: assert(false);break;
+        case (0xED<<3)|7: assert(false);break;
+    /* INC abs */
+        case (0xEE<<3)|0: _SA(c->PC++);break;
+        case (0xEE<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0xEE<<3)|2: _SA((_GD()<<8)|c->AD);break;
+        case (0xEE<<3)|3: c->AD=_GD();break;
+        case (0xEE<<3)|4: c->AD++;_NZ(c->AD);_SD(c->AD);_WR();break;
+        case (0xEE<<3)|5: _FETCH();break;
+        case (0xEE<<3)|6: assert(false);break;
+        case (0xEE<<3)|7: assert(false);break;
+    /* BBS6 zp,rel */
+        case (0xEF<<3)|0: _SA(c->PC++);break;
+        case (0xEF<<3)|1: _SA(_GD());break;
+        case (0xEF<<3)|2: c->AD=_GD();_SA(c->PC++);break;
+        case (0xEF<<3)|3: if(c->AD&(1<<6)){c->PC=c->PC+(int8_t)_GD();_FETCH();};_FETCH();break;
+        case (0xEF<<3)|4: assert(false);break;
+        case (0xEF<<3)|5: assert(false);break;
+        case (0xEF<<3)|6: assert(false);break;
+        case (0xEF<<3)|7: assert(false);break;
+    /* BEQ # */
+        case (0xF0<<3)|0: _SA(c->PC++);break;
+        case (0xF0<<3)|1: _SA(c->PC);c->AD=c->PC+(int8_t)_GD();if((c->P&0x2)!=0x2){_FETCH();};break;
+        case (0xF0<<3)|2: _SA((c->PC&0xFF00)|(c->AD&0x00FF));if((c->AD&0xFF00)==(c->PC&0xFF00)){c->PC=c->AD;c->irq_pip>>=1;c->nmi_pip>>=1;_FETCH();};break;
+        case (0xF0<<3)|3: c->PC=c->AD;_FETCH();break;
+        case (0xF0<<3)|4: assert(false);break;
+        case (0xF0<<3)|5: assert(false);break;
+        case (0xF0<<3)|6: assert(false);break;
+        case (0xF0<<3)|7: assert(false);break;
+    /* SBC (zp),Y */
+        case (0xF1<<3)|0: _SA(c->PC++);break;
+        case (0xF1<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0xF1<<3)|2: _SA((c->AD+1)&0xFF);c->AD=_GD();break;
+        case (0xF1<<3)|3: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->Y)&0xFF));c->IR+=(~((c->AD>>8)-((c->AD+c->Y)>>8)))&1;break;
+        case (0xF1<<3)|4: _SA(c->AD+c->Y);break;
+        case (0xF1<<3)|5: _m65c02_sbc(c,_GD());if(c->P&M65C02_DF){c->P=((c->P&~(M65C02_NF|M65C02_ZF))|((c->A&0xFF)?(c->A&M65C02_NF):M65C02_ZF));};_FETCH();break;
+        case (0xF1<<3)|6: assert(false);break;
+        case (0xF1<<3)|7: assert(false);break;
+    /* SBC (zp) */
+        case (0xF2<<3)|0: _SA(c->PC++);break;
+        case (0xF2<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0xF2<<3)|2: _SA((c->AD+1)&0xFF);c->AD=_GD();break;
+        case (0xF2<<3)|3: _SA((_GD()<<8)|c->AD);break;
+        case (0xF2<<3)|4: _m65c02_sbc(c,_GD());if(c->P&M65C02_DF){c->P=((c->P&~(M65C02_NF|M65C02_ZF))|((c->A&0xFF)?(c->A&M65C02_NF):M65C02_ZF));};_FETCH();break;
+        case (0xF2<<3)|5: assert(false);break;
+        case (0xF2<<3)|6: assert(false);break;
+        case (0xF2<<3)|7: assert(false);break;
+    /* NOP (zp),Y */
+        case (0xF3<<3)|0: _SA(c->PC);break;
+        case (0xF3<<3)|1: _FETCH();break;
+        case (0xF3<<3)|2: assert(false);break;
+        case (0xF3<<3)|3: assert(false);break;
+        case (0xF3<<3)|4: assert(false);break;
+        case (0xF3<<3)|5: assert(false);break;
+        case (0xF3<<3)|6: assert(false);break;
+        case (0xF3<<3)|7: assert(false);break;
+    /* LDD zp,X */
+        case (0xF4<<3)|0: _SA(c->PC++);break;
+        case (0xF4<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0xF4<<3)|2: _SA((c->AD+c->X)&0x00FF);break;
+        case (0xF4<<3)|3: _FETCH();break;
+        case (0xF4<<3)|4: assert(false);break;
+        case (0xF4<<3)|5: assert(false);break;
+        case (0xF4<<3)|6: assert(false);break;
+        case (0xF4<<3)|7: assert(false);break;
+    /* SBC zp,X */
+        case (0xF5<<3)|0: _SA(c->PC++);break;
+        case (0xF5<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0xF5<<3)|2: _SA((c->AD+c->X)&0x00FF);break;
+        case (0xF5<<3)|3: _m65c02_sbc(c,_GD());if(c->P&M65C02_DF){c->P=((c->P&~(M65C02_NF|M65C02_ZF))|((c->A&0xFF)?(c->A&M65C02_NF):M65C02_ZF));};_FETCH();break;
+        case (0xF5<<3)|4: assert(false);break;
+        case (0xF5<<3)|5: assert(false);break;
+        case (0xF5<<3)|6: assert(false);break;
+        case (0xF5<<3)|7: assert(false);break;
+    /* INC zp,X */
+        case (0xF6<<3)|0: _SA(c->PC++);break;
+        case (0xF6<<3)|1: c->AD=_GD();_SA(c->AD);break;
+        case (0xF6<<3)|2: _SA((c->AD+c->X)&0x00FF);break;
+        case (0xF6<<3)|3: c->AD=_GD();break;
+        case (0xF6<<3)|4: c->AD++;_NZ(c->AD);_SD(c->AD);_WR();break;
+        case (0xF6<<3)|5: _FETCH();break;
+        case (0xF6<<3)|6: assert(false);break;
+        case (0xF6<<3)|7: assert(false);break;
+    /* SMB7 zp */
+        case (0xF7<<3)|0: _SA(c->PC++);break;
+        case (0xF7<<3)|1: _SA(_GD());break;
+        case (0xF7<<3)|2: _SD(_GD()|(1<<7));_WR();break;
+        case (0xF7<<3)|3: _FETCH();break;
+        case (0xF7<<3)|4: assert(false);break;
+        case (0xF7<<3)|5: assert(false);break;
+        case (0xF7<<3)|6: assert(false);break;
+        case (0xF7<<3)|7: assert(false);break;
+    /* SED  */
+        case (0xF8<<3)|0: _SA(c->PC);break;
+        case (0xF8<<3)|1: c->P|=0x8;_FETCH();break;
+        case (0xF8<<3)|2: assert(false);break;
+        case (0xF8<<3)|3: assert(false);break;
+        case (0xF8<<3)|4: assert(false);break;
+        case (0xF8<<3)|5: assert(false);break;
+        case (0xF8<<3)|6: assert(false);break;
+        case (0xF8<<3)|7: assert(false);break;
+    /* SBC abs,Y */
+        case (0xF9<<3)|0: _SA(c->PC++);break;
+        case (0xF9<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0xF9<<3)|2: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->Y)&0xFF));c->IR+=(~((c->AD>>8)-((c->AD+c->Y)>>8)))&1;break;
+        case (0xF9<<3)|3: _SA(c->AD+c->Y);break;
+        case (0xF9<<3)|4: _m65c02_sbc(c,_GD());if(c->P&M65C02_DF){c->P=((c->P&~(M65C02_NF|M65C02_ZF))|((c->A&0xFF)?(c->A&M65C02_NF):M65C02_ZF));};_FETCH();break;
+        case (0xF9<<3)|5: assert(false);break;
+        case (0xF9<<3)|6: assert(false);break;
+        case (0xF9<<3)|7: assert(false);break;
+    /* PLX  */
+        case (0xFA<<3)|0: _SA(c->PC);break;
+        case (0xFA<<3)|1: _SA(0x0100|c->S++);break;
+        case (0xFA<<3)|2: _SA(0x0100|c->S);break;
+        case (0xFA<<3)|3: c->X=_GD();_NZ(c->X);_FETCH();break;
+        case (0xFA<<3)|4: assert(false);break;
+        case (0xFA<<3)|5: assert(false);break;
+        case (0xFA<<3)|6: assert(false);break;
+        case (0xFA<<3)|7: assert(false);break;
+    /* NOP abs,Y */
+        case (0xFB<<3)|0: _SA(c->PC);break;
+        case (0xFB<<3)|1: _FETCH();break;
+        case (0xFB<<3)|2: assert(false);break;
+        case (0xFB<<3)|3: assert(false);break;
+        case (0xFB<<3)|4: assert(false);break;
+        case (0xFB<<3)|5: assert(false);break;
+        case (0xFB<<3)|6: assert(false);break;
+        case (0xFB<<3)|7: assert(false);break;
+    /* LDD abs */
+        case (0xFC<<3)|0: _SA(c->PC++);break;
+        case (0xFC<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0xFC<<3)|2: _SA((_GD()<<8)|c->AD);break;
+        case (0xFC<<3)|3: _FETCH();break;
+        case (0xFC<<3)|4: assert(false);break;
+        case (0xFC<<3)|5: assert(false);break;
+        case (0xFC<<3)|6: assert(false);break;
+        case (0xFC<<3)|7: assert(false);break;
+    /* SBC abs,X */
+        case (0xFD<<3)|0: _SA(c->PC++);break;
+        case (0xFD<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0xFD<<3)|2: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->X)&0xFF));c->IR+=(~((c->AD>>8)-((c->AD+c->X)>>8)))&1;break;
+        case (0xFD<<3)|3: _SA(c->AD+c->X);break;
+        case (0xFD<<3)|4: _m65c02_sbc(c,_GD());if(c->P&M65C02_DF){c->P=((c->P&~(M65C02_NF|M65C02_ZF))|((c->A&0xFF)?(c->A&M65C02_NF):M65C02_ZF));};_FETCH();break;
+        case (0xFD<<3)|5: assert(false);break;
+        case (0xFD<<3)|6: assert(false);break;
+        case (0xFD<<3)|7: assert(false);break;
+    /* INC abs,X */
+        case (0xFE<<3)|0: _SA(c->PC++);break;
+        case (0xFE<<3)|1: _SA(c->PC++);c->AD=_GD();break;
+        case (0xFE<<3)|2: c->AD|=_GD()<<8;_SA((c->AD&0xFF00)|((c->AD+c->X)&0xFF));break;
+        case (0xFE<<3)|3: _SA(c->AD+c->X);break;
+        case (0xFE<<3)|4: c->AD=_GD();break;
+        case (0xFE<<3)|5: c->AD++;_NZ(c->AD);_SD(c->AD);_WR();break;
+        case (0xFE<<3)|6: _FETCH();break;
+        case (0xFE<<3)|7: assert(false);break;
+    /* BBS7 zp,rel */
+        case (0xFF<<3)|0: _SA(c->PC++);break;
+        case (0xFF<<3)|1: _SA(_GD());break;
+        case (0xFF<<3)|2: c->AD=_GD();_SA(c->PC++);break;
+        case (0xFF<<3)|3: if(c->AD&(1<<7)){c->PC=c->PC+(int8_t)_GD();_FETCH();};_FETCH();break;
+        case (0xFF<<3)|4: assert(false);break;
+        case (0xFF<<3)|5: assert(false);break;
+        case (0xFF<<3)|6: assert(false);break;
+        case (0xFF<<3)|7: assert(false);break;
+    // %>
+        default: _M65C02_UNREACHABLE;
+    }
+    __hidden_M6510_SET_PORT(pins, c->io_pins);
+    c->PINS = pins;
+    c->irq_pip <<= 1;
+    c->nmi_pip <<= 1;
+    return pins;
+}
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+#undef _SA
+#undef _SAD
+#undef _FETCH
+#undef _SD
+#undef _GD
+#undef _ON
+#undef _OFF
+#undef _RD
+#undef _WR
+#undef _NZ
+#endif /* CHIPS_IMPL */

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "sorbus-test-framework",
+  "version": "1.0.0",
+  "description": "Testing framework for Sorbus RP2040 chipset",
+  "main": "cpu_card.js",
+  "type": "module",
+  "scripts": {
+    "test": "node test_runner.js",
+    "build-lib": "make"
+  },
+  "keywords": [
+    "sorbus",
+    "rp2040",
+    "testing"
+  ],
+  "author": "",
+  "license": "GPL-3.0-or-later",
+  "dependencies": {
+    "koffi": "^2.15.0",
+    "uf2": "^2.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "ts-node": "^10.9.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e errexit
+
+if [[ ! -d rp2040js ]]; then
+  git clone --depth 1 https://github.com/c1570/rp2040js.git
+  cd rp2040js/
+  npm install
+  npx tsc demo/bootrom.ts --skipLibCheck
+  cd ..
+fi
+
+make
+npm install
+
+if [[ ! -f ../build/rp2040/jam_alpha_picotool.uf2 ]]; then
+  echo "Build Sorbus firmware first"
+  exit 1
+fi
+
+if egrep -q "pico_enable_stdio_usb.*1\)" ../src/rp2040/CMakeLists.txt ; then
+  echo -e "\n*** Best enable RP2 serial stdio for testing ***"
+  sleep 1
+fi
+
+npm run test

--- a/tests/test_runner.js
+++ b/tests/test_runner.js
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+/**
+ * Sorbus Testing Framework
+ *
+ * This test framework runs the RP2040 chipset code using rp2040js
+ * and wires it up with the 65C02 CPU card emulation.
+ *
+ * GPIO Pin Mapping:
+ * - Bits 0..15:   Address (A0-A15)
+ * - Bits 16..23:  Data (D0-D7)
+ * - Bit 24:       RW line (low: write)
+ * - Bit 25:       Clock line
+ * - Bit 26:       RDY line (CPU halts on low)
+ * - Bit 27:       IRQ line (active low)
+ * - Bit 28:       NMI line (active low)
+ * - Bit 29:       Reset line (active low)
+ */
+
+const MAX_CYCLES = -1;
+const DEBUG = 0;
+const RP_MHZ = 125;
+
+import { RP2040, USBCDC, GPIOPinState } from './rp2040js/dist/esm/index.js';
+import { bootromB1 } from './rp2040js/demo/bootrom.js';
+import * as fs from 'fs';
+import koffi from 'koffi/index.js';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { decodeBlock } from 'uf2';
+
+// Polyfill __dirname for ES modules
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// UF2 loading helper
+const FLASH_START_ADDRESS = 0x10000000;
+function loadUF2(filename, rp2040) {
+  const file = fs.openSync(filename, 'r');
+  const buffer = new Uint8Array(512);
+  while (fs.readSync(file, buffer) === buffer.length) {
+    const block = decodeBlock(buffer);
+    const { flashAddress, payload } = block;
+    rp2040.flash.set(payload, flashAddress - FLASH_START_ADDRESS);
+  }
+  fs.closeSync(file);
+}
+
+const FIRMWARE_PATH = `${__dirname}/../build/rp2040/jam_alpha_picotool.uf2`;
+const INITIAL_PC = 0x10000000;
+
+// Load the CPU card library
+const libraryPath = path.join(__dirname, 'libcpu_card.so');
+const lib = koffi.load(libraryPath);
+
+const cpu_card_init = lib.func('void cpu_card_init()');
+const cpu_card_get_pins = lib.func('uint64_t cpu_card_get_pins()');
+const cpu_card_tick = lib.func('uint64_t cpu_card_tick(uint64_t input_pins)');
+
+// Pin masks (matching bus.h)
+const MASK_ADDRESS  = 0x0000FFFFn; // Bits 0-15
+const MASK_DATA     = 0x00FF0000n; // Bits 16-23
+const MASK_RW       = 0x01000000n; // Bit 24
+const MASK_CLOCK    = 0x02000000n; // Bit 25
+const MASK_RDY      = 0x04000000n; // Bit 26
+const MASK_IRQ      = 0x08000000n; // Bit 27
+const MASK_NMI      = 0x10000000n; // Bit 28
+const MASK_RESET    = 0x20000000n; // Bit 29
+const MASK_SYNC     = 0x40000000n; // Bit 30
+const SHIFT_DATA    = 16n;
+
+// Initialize the CPU card
+console.log('Initializing 65C02 CPU card...');
+cpu_card_init();
+const initialCpuPins = BigInt(cpu_card_get_pins());
+console.log(`Initial CPU pins: 0x${initialCpuPins.toString(16)}`);
+
+// Initialize RP2040
+console.log('Initializing RP2040...');
+const mcu = new RP2040();
+mcu.loadBootrom(bootromB1);
+
+// Load firmware
+if (fs.existsSync(FIRMWARE_PATH)) {
+  console.log(`Loading firmware from ${FIRMWARE_PATH}`);
+  loadUF2(FIRMWARE_PATH, mcu);
+  console.log('Firmware loaded successfully');
+} else {
+  console.error(`Firmware not found at ${FIRMWARE_PATH}`);
+  process.exit(1);
+}
+
+console.log("USB CDC output is disabled, use RP2 stdio via UART");
+/*
+// wiring up RP2 USB CDC
+const cdc = new USBCDC(mcu.usbCtrl);
+cdc.onDeviceConnected = () => {
+  console.log("USB CDC connected");
+};
+cdc.onSerialData = (value) => {
+  process.stdout.write(value);
+};
+if (process.stdin.isTTY) {
+  process.stdin.setRawMode(true);
+}
+process.stdin.on('data', (chunk) => {
+  // 24 is Ctrl+X
+  if (chunk[0] === 24) {
+    process.exit(0);
+  }
+  for (const byte of chunk) {
+    cdc.sendSerialByte(byte);
+  }
+});
+*/
+
+// Set up UART output
+mcu.uart[0].onByte = (value) => {
+  process.stdout.write(new Uint8Array([value]));
+};
+if (process.stdin.isTTY) {
+  process.stdin.setRawMode(true);
+}
+process.stdin.on('data', (chunk) => {
+  // 24 is Ctrl+X, 3 is Ctrl-C
+  if (chunk[0] === 24 || chunk[0] === 3) {
+    process.exit(0);
+  }
+  for (const byte of chunk) {
+    // console.log(`key in: ${byte}`);
+    mcu.uart[0].feedByte(byte);
+  }
+});
+
+// Set initial program counter for both cores
+mcu.core0.PC = INITIAL_PC;
+mcu.core1.PC = INITIAL_PC;
+
+// GPIO state tracking
+// Start with the initial CPU pin state
+let currentPins = initialCpuPins;
+
+mcu.gpio[29].setInputValue(1); // start with RESET high/inactive
+
+// Main emulation loop
+console.log('Starting emulation...');
+console.log('Press Ctrl+C/Ctrl+X to stop');
+
+let nextTimeUpdate = 0;
+let prevClockState = false;
+let cpuCycleCount = 0;
+
+// original 65C02 bus timing (at 5V):
+// CPU reads data on falling PHI2 (expects it set up tDSR=10ns before PHI2 falling and held tDHR=10ns after PHI2 falling)
+// CPU writes data tMDS=25ns after rising PHI2, holds it until tDHW=10ns after falling PHI2
+// CPU writes address/RW/SYNC tADS=30ns after falling PHI2, holds it until tAH=10ns after falling PHI2
+// IRQ,NMI,RDY,RES is tPCS/tPCH, just like data read
+// in short: fall phi2 - CPU reads data/flags - 30ns - CPU writes address - rise phi2 - 25ns - CPU writes data
+
+let cpuTickCountdown = -1;
+const cpuPosedgeToCPUDataWrite = Math.round(25*RP_MHZ/1000);
+const cpuNegedgeToCPUAddrWrite = Math.round(30*RP_MHZ/1000);
+
+function runEmulation() {
+  for (let j = 0; j < 200000; j++) {
+    // Step the RP2040
+    let rpStartCycles = mcu.cycles;
+    mcu.step();
+    let rpCyclesElapsed = mcu.cycles - rpStartCycles;
+
+    const currentClockState = mcu.gpio[25].value;
+    if (currentClockState && !prevClockState) {
+      // positive clock edge: after 25ns, write data
+      cpuTickCountdown = cpuPosedgeToCPUDataWrite;
+    } else if (!currentClockState && prevClockState) {
+      // negative clock edge: read data/flags; then, after 30ns, write next address
+      cpuTickCountdown = cpuNegedgeToCPUAddrWrite;
+
+      if (currentPins & MASK_RW) {
+        // Get RP2040 data (GPIO 16-23) and put on 65c02 pins
+        for (let i = 16; i < 24; i++) {
+          if (mcu.gpio[i].value == GPIOPinState.High) {
+            currentPins |= (1n << BigInt(i));
+          } else {
+            currentPins &= ~(1n << BigInt(i));
+          }
+        }
+      }
+      // Copy RP2040 control signals to 6502 pins
+      // Note: IRQ, NMI, RESET, RDY are active-low on GPIO but active-high in m6502
+      if (!mcu.gpio[26].value) currentPins |= MASK_RDY; else currentPins &= ~MASK_RDY;  // Inverted!
+      if (!mcu.gpio[27].value) currentPins |= MASK_IRQ; else currentPins &= ~MASK_IRQ;  // Inverted!
+      if (!mcu.gpio[28].value) currentPins |= MASK_NMI; else currentPins &= ~MASK_NMI;  // Inverted!
+      if (!mcu.gpio[29].value) { currentPins |= MASK_RESET; currentPins |= MASK_SYNC; } else currentPins &= ~MASK_RESET;  // Inverted, also set SYNC if we have RESET to get m6502 unstuck
+    }
+    prevClockState = currentClockState;
+
+    if (cpuTickCountdown > 0) {
+      cpuTickCountdown -= rpCyclesElapsed;
+      if (cpuTickCountdown < 0) {
+        cpuTickCountdown = 0;
+      }
+    }
+
+    if (cpuTickCountdown == 0 && currentClockState == GPIOPinState.High) {
+      // 25ns after PHI2 positive edge: write data (if CPU signals write)
+      cpuTickCountdown--;
+
+      if (!(currentPins & MASK_RW)) {
+        // Copy m6502 bus data to RP2040 GPIO 16-23
+        for (let i = 16; i < 24; i++) {
+          const value = (currentPins & (1n << BigInt(i))) !== 0n;
+          mcu.gpio[i].setInputValue(value);
+        }
+      }
+
+    } else if (cpuTickCountdown == 0 && currentClockState == GPIOPinState.Low) {
+      // 30ns after PHI2 negative edge: clock m65c02
+      // internally, consumes data (on read cycle) or writes next data (on write cycle)
+      // externally, writes next bus address
+      cpuTickCountdown--;
+
+      if (DEBUG) {
+        const addr = Number(currentPins & MASK_ADDRESS);
+        const data = Number((currentPins & MASK_DATA) >> BigInt(SHIFT_DATA));
+        const rw = (currentPins & MASK_RW) !== 0n ? 'R' : 'W';
+        const clock = (currentPins & MASK_CLOCK) !== 0n ? '1' : '0';
+        const rdy = (currentPins & MASK_RDY) !== 0n ? '1' : '0';
+        const irq = (currentPins & MASK_IRQ) !== 0n ? '1' : '0';
+        const nmi = (currentPins & MASK_NMI) !== 0n ? '1' : '0';
+        const reset = (currentPins & MASK_RESET) !== 0n ? '1' : '0';
+        const sync = (currentPins & MASK_SYNC) !== 0n ? '1' : '0';
+        console.log(`CPU #${cpuCycleCount.toString().padStart(6, ' ')}: ` +
+                    `BusAddr=0x${addr.toString(16).padStart(4, '0')} ` +
+                    `BusData=0x${data.toString(16).padStart(2, '0')} ` +
+                    `RW=${rw} CLK=${clock} RDY=${rdy} IRQ=${irq} NMI=${nmi} RST=${reset} SYNC=${sync} `);
+      }
+
+      // Tick the m6502 CPU
+      currentPins = BigInt(cpu_card_tick(Number(currentPins)));
+      cpuCycleCount++;
+
+      // Copy m6502 CPU address lines to RP2040 GPIO 0-15
+      for (let i = 0; i < 16; i++) {
+        const value = (currentPins & (1n << BigInt(i))) !== 0n;
+        mcu.gpio[i].setInputValue(value);
+      }
+
+      // Update CPU output control signals
+      mcu.gpio[24].setInputValue((currentPins & MASK_RW) !== 0n);
+    }
+    mcu.gpio[25].setInputValue(mcu.gpio[25].value); // just read back CLOCK value
+    mcu.gpio[26].setInputValue(mcu.gpio[26].value); // just read back RDY value
+    mcu.gpio[27].setInputValue(mcu.gpio[27].value); // just read back IRQ value
+    mcu.gpio[28].setInputValue(mcu.gpio[28].value); // just read back NMI value
+    mcu.gpio[29].setInputValue(mcu.gpio[29].value); // just read back RESET value
+
+    if (mcu.cycles > nextTimeUpdate) {
+      const time = ((mcu.cycles / 125000000) >>> 0) / 10;
+      console.log(`\nTime: ${time.toFixed(1)}s, rpCycleCount: ${mcu.cycles}, 65C02 Cycles: ${cpuCycleCount}\n`);
+      nextTimeUpdate += 40000000;
+    }
+  }
+  if (MAX_CYCLES < 0 || mcu.cycles < MAX_CYCLES) {
+    setTimeout(runEmulation);
+  } else {
+    console.log(`\nEmulation stopped after ${mcu.cycles} rp cycles and ${cpuCycleCount} 65C02 cycles`);
+  }
+}
+
+// have to use setTimeout as otherwise the keyboard callback never gets called
+setTimeout(runEmulation);

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "lib": ["ES2020"],
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": [
+    "*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}


### PR DESCRIPTION
A testing framework that runs the Sorbus JAM RP2040 chipset code using https://github.com/c1570/rp2040js/ and wires it up with a 65C02 CPU card emulation based on https://github.com/floooh/chips .

You may not want the pico_enable_stdio_* changes.